### PR TITLE
[bug/RANDOM-18] 레벨 목록으로 돌아와 다른 레벨 메뉴를 클릭했을 때, 선택한 레벨의 목록이 보여지지 않는 문제

### DIFF
--- a/app/src/main/java/com/w36495/randomrithm/ui/level/LevelFragment.kt
+++ b/app/src/main/java/com/w36495/randomrithm/ui/level/LevelFragment.kt
@@ -14,9 +14,10 @@ import com.w36495.randomrithm.data.remote.RetrofitClient
 import com.w36495.randomrithm.databinding.FragmentLevelBinding
 import com.w36495.randomrithm.domain.repository.LevelRepositoryImpl
 import com.w36495.randomrithm.domain.usecase.GetLevelsUseCase
+import com.w36495.randomrithm.ui.problem.ProblemFragment
 import com.w36495.randomrithm.ui.viewmodel.LevelViewModelFactory
 
-class LevelFragment : Fragment() {
+class LevelFragment : Fragment(), LevelItemClickListener {
 
     private var _binding: FragmentLevelBinding? = null
     private val binding: FragmentLevelBinding get() = _binding!!
@@ -46,6 +47,10 @@ class LevelFragment : Fragment() {
             viewModel.getLevels(it)
             binding.layoutTab.getTabAt(it)?.select()
         }
+
+        viewModel.levels.observe(requireActivity()) {
+            levelListAdapter.setLevelList(it)
+        }
     }
 
     private fun setupListView() {
@@ -74,14 +79,12 @@ class LevelFragment : Fragment() {
         viewModel = ViewModelProvider(requireActivity(), viewModelFactory)[LevelViewModel::class.java]
     }
 
-    private fun initSelectLevel() {
+    override fun onClickLevelItem(level: Int) {
         parentFragmentManager.beginTransaction()
-            .addToBackStack(LevelListFragment.TAG)
+            .addToBackStack(ProblemFragment.TAG)
             .setReorderingAllowed(true)
-            .replace(R.id.container_level_fragment, LevelListFragment())
+            .replace(R.id.container_fragment, ProblemFragment.newInstance(level))
             .commit()
-
-        viewModel.getLevels(0)
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/w36495/randomrithm/ui/level/LevelFragment.kt
+++ b/app/src/main/java/com/w36495/randomrithm/ui/level/LevelFragment.kt
@@ -41,6 +41,11 @@ class LevelFragment : Fragment() {
         setupViewModel()
         setupTabLayout()
         setupListView()
+
+        viewModel.menu.observe(requireActivity()) {
+            viewModel.getLevels(it)
+            binding.layoutTab.getTabAt(it)?.select()
+        }
     }
 
     private fun setupListView() {
@@ -55,7 +60,7 @@ class LevelFragment : Fragment() {
         binding.layoutTab.addOnTabSelectedListener(object : OnTabSelectedListener {
             override fun onTabSelected(tab: TabLayout.Tab?) {
                 tab?.let {
-                    viewModel.getLevels(it.position)
+                    viewModel.changeMenu(it.position)
                 }
             }
 

--- a/app/src/main/java/com/w36495/randomrithm/ui/level/LevelFragment.kt
+++ b/app/src/main/java/com/w36495/randomrithm/ui/level/LevelFragment.kt
@@ -24,6 +24,8 @@ class LevelFragment : Fragment() {
     private lateinit var viewModelFactory: LevelViewModelFactory
     private lateinit var viewModel: LevelViewModel
 
+    private lateinit var levelListAdapter: LevelListAdapter
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -38,8 +40,15 @@ class LevelFragment : Fragment() {
 
         setupViewModel()
         setupTabLayout()
+        setupListView()
+    }
 
-        initSelectLevel()
+    private fun setupListView() {
+        levelListAdapter = LevelListAdapter().apply {
+            setLevelItemClickListener(this@LevelFragment)
+        }
+
+        binding.lvLevels.adapter = levelListAdapter
     }
 
     private fun setupTabLayout() {

--- a/app/src/main/java/com/w36495/randomrithm/ui/level/LevelListAdapter.kt
+++ b/app/src/main/java/com/w36495/randomrithm/ui/level/LevelListAdapter.kt
@@ -9,7 +9,7 @@ import com.w36495.randomrithm.data.entity.LevelDTO
 import com.w36495.randomrithm.databinding.ItemLevelBinding
 
 class LevelListAdapter : BaseAdapter() {
-    private val levelList = arrayListOf<LevelDTO>()
+    private var levelList = emptyList<LevelDTO>()
     private lateinit var levelItemClickListener: LevelItemClickListener
 
     override fun getCount(): Int = levelList.size
@@ -36,17 +36,15 @@ class LevelListAdapter : BaseAdapter() {
 
         holder.bind(levelList[position])
 
-            holder.onClickItem = {
-                levelItemClickListener.onClickLevelItem(levelList[position].level)
-            }
+        holder.onClickItem = {
+            levelItemClickListener.onClickLevelItem(levelList[position].level)
         }
 
         return convertView
     }
 
     fun setLevelList(list: List<LevelDTO>) {
-        levelList.clear()
-        levelList.addAll(list)
+        levelList = list.toList()
 
         notifyDataSetChanged()
     }

--- a/app/src/main/java/com/w36495/randomrithm/ui/level/LevelListAdapter.kt
+++ b/app/src/main/java/com/w36495/randomrithm/ui/level/LevelListAdapter.kt
@@ -28,7 +28,13 @@ class LevelListAdapter : BaseAdapter() {
             convertView = binding.root
 
             holder = LevelListViewHolder(binding)
-            holder.bind(levelList[position])
+            convertView.tag = holder
+        } else {
+            binding = ItemLevelBinding.bind(convertView)
+            holder = convertView.tag as LevelListViewHolder
+        }
+
+        holder.bind(levelList[position])
 
             holder.onClickItem = {
                 levelItemClickListener.onClickLevelItem(levelList[position].level)

--- a/app/src/main/java/com/w36495/randomrithm/ui/level/LevelViewModel.kt
+++ b/app/src/main/java/com/w36495/randomrithm/ui/level/LevelViewModel.kt
@@ -13,8 +13,14 @@ class LevelViewModel(
     private val getLevelsUseCase: GetLevelsUseCase
 ) : ViewModel() {
     private var _levels = MutableLiveData<List<LevelDTO>>()
-    val levels: LiveData<List<LevelDTO>>
-        get() = _levels
+    private var _menu = MutableLiveData(0)
+
+    val levels: LiveData<List<LevelDTO>> get() = _levels
+    val menu: LiveData<Int> get() = _menu
+
+    fun changeMenu(selectMenu: Int) {
+        _menu.value = selectMenu
+    }
 
     fun getLevels(selectedLevel: Int) {
         viewModelScope.launch {

--- a/app/src/main/java/com/w36495/randomrithm/ui/problem/ProblemFragment.kt
+++ b/app/src/main/java/com/w36495/randomrithm/ui/problem/ProblemFragment.kt
@@ -30,7 +30,7 @@ class ProblemFragment : Fragment() {
 
     private var currentTag: String? = null
     private var currentLevel: Int? = null
-    private val currentProblems = mutableListOf<Problem>()
+    private var currentProblems = emptyList<Problem>()
 
     private lateinit var levels: Array<String>
     private lateinit var levelBackgroundColors: IntArray
@@ -65,8 +65,7 @@ class ProblemFragment : Fragment() {
         }
 
         problemViewModel.problems.observe(requireActivity()) {
-            currentProblems.clear()
-            currentProblems.addAll(it)
+            currentProblems = it.toList()
 
             getRandomProblem()
         }
@@ -124,5 +123,14 @@ class ProblemFragment : Fragment() {
 
     companion object {
         const val TAG: String = "ProblemFragment"
+        fun newInstance(level: Int): Fragment {
+            val problemFragment = ProblemFragment().apply {
+                arguments = Bundle().apply {
+                    putInt("level", level)
+                }
+            }
+
+            return problemFragment
+        }
     }
 }

--- a/app/src/main/java/com/w36495/randomrithm/ui/problem/ProblemFragment.kt
+++ b/app/src/main/java/com/w36495/randomrithm/ui/problem/ProblemFragment.kt
@@ -1,11 +1,9 @@
 package com.w36495.randomrithm.ui.problem
 
-import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.annotation.RequiresApi
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import com.google.android.material.chip.Chip

--- a/app/src/main/java/com/w36495/randomrithm/ui/problem/ProblemFragment.kt
+++ b/app/src/main/java/com/w36495/randomrithm/ui/problem/ProblemFragment.kt
@@ -92,7 +92,7 @@ class ProblemFragment : Fragment() {
     }
 
     private fun getRandomProblem() {
-        if (currentProblems.isNotEmpty()) {
+        if (currentProblems.isNotEmpty() && currentProblems.all { it.level.toInt() == currentLevel }) {
             val randomProblem = currentProblems.random()
 
             randomProblem.run {

--- a/app/src/main/res/layout/fragment_level.xml
+++ b/app/src/main/res/layout/fragment_level.xml
@@ -67,8 +67,8 @@
 
     </com.google.android.material.tabs.TabLayout>
 
-    <androidx.fragment.app.FragmentContainerView
-        android:id="@+id/container_level_fragment"
+    <ListView
+        android:id="@+id/lv_levels"
         android:layout_width="0dp"
         android:layout_height="0dp"
         app:layout_constraintBottom_toBottomOf="parent"


### PR DESCRIPTION
## ISSUE
레벨 목록으로 돌아와 다른 레벨 메뉴를 클릭했을 때, 선택한 레벨의 목록이 보여지지 않는 문제 (#18)

## 해결과정
### 1️⃣ 선택한 레벨의 목록이 보이지 않는 문제
``` kotlin
override fun getView(position: Int, view: View?, parent: ViewGroup?): View {
        var convertView: View? = view
        var binding: ItemLevelBinding
        var holder: LevelListViewHolder

        if (convertView == null) {
            binding = ItemLevelBinding.inflate(LayoutInflater.from(parent!!.context), parent, false)
            convertView = binding.root

            holder = LevelListViewHolder(binding)
            holder.bind(levelList[position])

            holder.onClickItem = {
                levelItemClickListener.onClickLevelItem(levelList[position].level)
            }
        }

        return convertView
    }
```
ListView 를 화면에 표시하기 위해 사용한 BaseAdapter 내 getView() 메서드에서 **view 가 null 이 아닌 상태에 대한 처리를 해주지 못하였다**는 것을 알게되었다.

``` kotlin
override fun getView(position: Int, view: View?, parent: ViewGroup?): View {
        var convertView: View? = view
        var binding: ItemLevelBinding
        var holder: LevelListViewHolder

        if (convertView == null) {
            binding = ItemLevelBinding.inflate(LayoutInflater.from(parent!!.context), parent, false)
            convertView = binding.root

            holder = LevelListViewHolder(binding)
            convertView.tag = holder
        } else {
            binding = ItemLevelBinding.bind(convertView)
            holder = convertView.tag as LevelListViewHolder
        }

        holder.bind(levelList[position])

        holder.onClickItem = {
            levelItemClickListener.onClickLevelItem(levelList[position].level)
        }

        return convertView
    }
```
tag 를 통해 생성한 ViewHolder 를 저장하고, view 를 재사용하기 위해 저장해놓았던 view 의 tag 를 통해 holder 를 사용할 수 있도록 변경해주었다!

### 2️⃣ 이전에 선택한 레벨의 문제가 아닌, 새로운 레벨의 문제를 보고싶을 때, NullPointerException 이 발생한 문제
**문제가 화면에 보여지는 과정**
1. 레벨(실버 1) 선택
2. 레벨(실버 1)에 대한 문제 50개 가져오기
3. 전역 변수인 currentProblem 에 문제 50개 저장
4. currentProblem 에 random() 메서드를 사용해서 문제 1개 추출
5. 해당 문제를 화면에 표시

새로운 레벨을 선택하게되면 그에 맞는 새로운 50개의 문제를 가져와 currentProblems 에 다시 저장되어, 위의 과정을 거쳐서 화면에 1문제가 보여지게된다. 하지만 이 과정에서 NullPointerException 이 발생했다.

그런데 정확히 어느 부분때문인지는 파악하지 못했다 .. 지금까지의 추측은 아래와 같다.
(1) currentProblems 에 저장되어있던 문제들 중 1문제가 view 에 binding 됨
(2) 새로운 50개의 문제로 변경되고, 다시 그 중 1문제가 view 에 binding 됨
내가 생각했던 Fragment 의 생명주기에서는 NullPointerException 이 날 수 없는 것 같은데 .. 어렵다 🥲

하지만 일단 지속해서 기능을 만들어야하기때문에 선택한 대안은 **현재 가지고 있는 50개의 문제들의 레벨과 현재 선택한 레벨이 일치하는지 확인을 한 후에 View 에 보여지도록** 수정했다.
``` kotlin
private fun getRandomProblem() {
        if (currentProblems.isNotEmpty() && currentProblems.all { it.level.toInt() == currentLevel }) {
            val randomProblem = currentProblems.random()

            randomProblem.run {
                binding.tvTitle.text = title
                binding.tvId.text = id.toString()
                binding.tvLevel.text = levels[level.toInt()]
                binding.tvLevel.setBackgroundColor(levelBackgroundColors[level.toInt()])
                showAlgorithmChips(tags)
            }
        }
    }
```

## 결과
|수정 전|수정 후|
|:--:|:--:|
|![2024-01-1019 08 37-ezgif com-video-to-gif-converter](https://github.com/w36495/Randomrithm/assets/52291662/6c1dfd25-e802-4567-89fc-1ee7226110eb)|![2024-01-1816 52 26-ezgif com-video-to-gif-converter](https://github.com/w36495/Randomrithm/assets/52291662/9fb75b9f-a141-4566-a2f3-af43ec546367)|