### PR TITLE
[refactor/RANDOM-20] 문제 목록을 위한 ViewPager2 적용하기

### DIFF
--- a/app/src/main/java/com/w36495/randomrithm/data/repository/LevelRepositoryImpl.kt
+++ b/app/src/main/java/com/w36495/randomrithm/data/repository/LevelRepositoryImpl.kt
@@ -1,8 +1,8 @@
-package com.w36495.randomrithm.domain.repository
+package com.w36495.randomrithm.data.repository
 
 import com.w36495.randomrithm.data.datasource.LevelRemoteDataSource
 import com.w36495.randomrithm.data.entity.LevelDTO
-import com.w36495.randomrithm.data.repository.LevelRepository
+import com.w36495.randomrithm.domain.repository.LevelRepository
 import retrofit2.Response
 
 class LevelRepositoryImpl(

--- a/app/src/main/java/com/w36495/randomrithm/data/repository/ProblemRepositoryImpl.kt
+++ b/app/src/main/java/com/w36495/randomrithm/data/repository/ProblemRepositoryImpl.kt
@@ -1,8 +1,8 @@
-package com.w36495.randomrithm.domain.repository
+package com.w36495.randomrithm.data.repository
 
 import com.w36495.randomrithm.data.datasource.ProblemRemoteDataSource
 import com.w36495.randomrithm.data.entity.ProblemDTO
-import com.w36495.randomrithm.data.repository.ProblemRepository
+import com.w36495.randomrithm.domain.repository.ProblemRepository
 import retrofit2.Response
 
 class ProblemRepositoryImpl(

--- a/app/src/main/java/com/w36495/randomrithm/data/repository/TagRepositoryImpl.kt
+++ b/app/src/main/java/com/w36495/randomrithm/data/repository/TagRepositoryImpl.kt
@@ -1,8 +1,8 @@
-package com.w36495.randomrithm.domain.repository
+package com.w36495.randomrithm.data.repository
 
 import com.w36495.randomrithm.data.datasource.TagRemoteDataSource
 import com.w36495.randomrithm.data.entity.AlgorithmDTO
-import com.w36495.randomrithm.data.repository.TagRepository
+import com.w36495.randomrithm.domain.repository.TagRepository
 import retrofit2.Response
 
 class TagRepositoryImpl(

--- a/app/src/main/java/com/w36495/randomrithm/domain/repository/LevelRepository.kt
+++ b/app/src/main/java/com/w36495/randomrithm/domain/repository/LevelRepository.kt
@@ -1,4 +1,4 @@
-package com.w36495.randomrithm.data.repository
+package com.w36495.randomrithm.domain.repository
 
 import com.w36495.randomrithm.data.entity.LevelDTO
 import retrofit2.Response

--- a/app/src/main/java/com/w36495/randomrithm/domain/repository/ProblemRepository.kt
+++ b/app/src/main/java/com/w36495/randomrithm/domain/repository/ProblemRepository.kt
@@ -1,4 +1,4 @@
-package com.w36495.randomrithm.data.repository
+package com.w36495.randomrithm.domain.repository
 
 import com.w36495.randomrithm.data.entity.ProblemDTO
 import com.w36495.randomrithm.data.entity.ProblemItem

--- a/app/src/main/java/com/w36495/randomrithm/domain/repository/TagRepository.kt
+++ b/app/src/main/java/com/w36495/randomrithm/domain/repository/TagRepository.kt
@@ -1,4 +1,4 @@
-package com.w36495.randomrithm.data.repository
+package com.w36495.randomrithm.domain.repository
 
 import com.w36495.randomrithm.data.entity.AlgorithmDTO
 import retrofit2.Response

--- a/app/src/main/java/com/w36495/randomrithm/domain/usecase/GetLevelsUseCase.kt
+++ b/app/src/main/java/com/w36495/randomrithm/domain/usecase/GetLevelsUseCase.kt
@@ -1,7 +1,7 @@
 package com.w36495.randomrithm.domain.usecase
 
 import com.w36495.randomrithm.data.entity.LevelDTO
-import com.w36495.randomrithm.domain.repository.LevelRepositoryImpl
+import com.w36495.randomrithm.data.repository.LevelRepositoryImpl
 import retrofit2.Response
 
 class GetLevelsUseCase(

--- a/app/src/main/java/com/w36495/randomrithm/domain/usecase/GetProblemsByLevelUseCase.kt
+++ b/app/src/main/java/com/w36495/randomrithm/domain/usecase/GetProblemsByLevelUseCase.kt
@@ -1,7 +1,7 @@
 package com.w36495.randomrithm.domain.usecase
 
 import com.w36495.randomrithm.data.entity.ProblemDTO
-import com.w36495.randomrithm.domain.repository.ProblemRepositoryImpl
+import com.w36495.randomrithm.data.repository.ProblemRepositoryImpl
 import retrofit2.Response
 
 class GetProblemsByLevelUseCase(

--- a/app/src/main/java/com/w36495/randomrithm/domain/usecase/GetProblemsByTagUseCase.kt
+++ b/app/src/main/java/com/w36495/randomrithm/domain/usecase/GetProblemsByTagUseCase.kt
@@ -1,7 +1,7 @@
 package com.w36495.randomrithm.domain.usecase
 
 import com.w36495.randomrithm.data.entity.ProblemDTO
-import com.w36495.randomrithm.domain.repository.ProblemRepositoryImpl
+import com.w36495.randomrithm.data.repository.ProblemRepositoryImpl
 import retrofit2.Response
 
 class GetProblemsByTagUseCase(

--- a/app/src/main/java/com/w36495/randomrithm/domain/usecase/GetTagsUseCase.kt
+++ b/app/src/main/java/com/w36495/randomrithm/domain/usecase/GetTagsUseCase.kt
@@ -1,7 +1,7 @@
 package com.w36495.randomrithm.domain.usecase
 
 import com.w36495.randomrithm.data.entity.AlgorithmDTO
-import com.w36495.randomrithm.domain.repository.TagRepositoryImpl
+import com.w36495.randomrithm.data.repository.TagRepositoryImpl
 import retrofit2.Response
 
 class GetTagsUseCase(

--- a/app/src/main/java/com/w36495/randomrithm/ui/level/LevelFragment.kt
+++ b/app/src/main/java/com/w36495/randomrithm/ui/level/LevelFragment.kt
@@ -6,8 +6,8 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
-import com.google.android.material.tabs.TabLayout
-import com.google.android.material.tabs.TabLayout.OnTabSelectedListener
+import androidx.viewpager2.widget.ViewPager2
+import com.google.android.material.tabs.TabLayoutMediator
 import com.w36495.randomrithm.R
 import com.w36495.randomrithm.data.datasource.LevelRemoteDataSource
 import com.w36495.randomrithm.data.remote.RetrofitClient
@@ -25,7 +25,7 @@ class LevelFragment : Fragment(), LevelItemClickListener {
     private lateinit var viewModelFactory: LevelViewModelFactory
     private lateinit var viewModel: LevelViewModel
 
-    private lateinit var levelListAdapter: LevelListAdapter
+    private lateinit var viewPagerAdapter: LevelViewPagerAdapter
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -40,6 +40,7 @@ class LevelFragment : Fragment(), LevelItemClickListener {
         super.onViewCreated(view, savedInstanceState)
 
         setupViewModel()
+        setupViewPager()
         setupTabLayout()
         setupListView()
 
@@ -79,12 +80,23 @@ class LevelFragment : Fragment(), LevelItemClickListener {
         viewModel = ViewModelProvider(requireActivity(), viewModelFactory)[LevelViewModel::class.java]
     }
 
-    override fun onClickLevelItem(level: Int) {
-        parentFragmentManager.beginTransaction()
-            .addToBackStack(ProblemFragment.TAG)
-            .setReorderingAllowed(true)
-            .replace(R.id.container_fragment, ProblemFragment.newInstance(level))
-            .commit()
+    private fun setupViewPager() {
+        viewPagerAdapter = LevelViewPagerAdapter(this)
+
+        binding.containerViewpager.adapter = viewPagerAdapter
+        binding.containerViewpager.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
+            override fun onPageSelected(position: Int) {
+                super.onPageSelected(position)
+
+                viewModel.getLevels(position)
+            }
+        })
+    }
+
+    private fun setupTabLayout() {
+        TabLayoutMediator(binding.layoutTab, binding.containerViewpager) { tab, position ->
+            tab.text = resources.getStringArray(R.array.levelForTabItem)[position]
+        }.attach()
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/w36495/randomrithm/ui/level/LevelFragment.kt
+++ b/app/src/main/java/com/w36495/randomrithm/ui/level/LevelFragment.kt
@@ -12,7 +12,7 @@ import com.w36495.randomrithm.R
 import com.w36495.randomrithm.data.datasource.LevelRemoteDataSource
 import com.w36495.randomrithm.data.remote.RetrofitClient
 import com.w36495.randomrithm.databinding.FragmentLevelBinding
-import com.w36495.randomrithm.domain.repository.LevelRepositoryImpl
+import com.w36495.randomrithm.data.repository.LevelRepositoryImpl
 import com.w36495.randomrithm.domain.usecase.GetLevelsUseCase
 import com.w36495.randomrithm.ui.viewmodel.LevelViewModelFactory
 

--- a/app/src/main/java/com/w36495/randomrithm/ui/level/LevelFragment.kt
+++ b/app/src/main/java/com/w36495/randomrithm/ui/level/LevelFragment.kt
@@ -14,10 +14,9 @@ import com.w36495.randomrithm.data.remote.RetrofitClient
 import com.w36495.randomrithm.databinding.FragmentLevelBinding
 import com.w36495.randomrithm.domain.repository.LevelRepositoryImpl
 import com.w36495.randomrithm.domain.usecase.GetLevelsUseCase
-import com.w36495.randomrithm.ui.problem.ProblemFragment
 import com.w36495.randomrithm.ui.viewmodel.LevelViewModelFactory
 
-class LevelFragment : Fragment(), LevelItemClickListener {
+class LevelFragment : Fragment() {
 
     private var _binding: FragmentLevelBinding? = null
     private val binding: FragmentLevelBinding get() = _binding!!
@@ -42,37 +41,6 @@ class LevelFragment : Fragment(), LevelItemClickListener {
         setupViewModel()
         setupViewPager()
         setupTabLayout()
-        setupListView()
-
-        viewModel.menu.observe(requireActivity()) {
-            viewModel.getLevels(it)
-            binding.layoutTab.getTabAt(it)?.select()
-        }
-
-        viewModel.levels.observe(requireActivity()) {
-            levelListAdapter.setLevelList(it)
-        }
-    }
-
-    private fun setupListView() {
-        levelListAdapter = LevelListAdapter().apply {
-            setLevelItemClickListener(this@LevelFragment)
-        }
-
-        binding.lvLevels.adapter = levelListAdapter
-    }
-
-    private fun setupTabLayout() {
-        binding.layoutTab.addOnTabSelectedListener(object : OnTabSelectedListener {
-            override fun onTabSelected(tab: TabLayout.Tab?) {
-                tab?.let {
-                    viewModel.changeMenu(it.position)
-                }
-            }
-
-            override fun onTabUnselected(tab: TabLayout.Tab?) { }
-            override fun onTabReselected(tab: TabLayout.Tab?) { }
-        })
     }
 
     private fun setupViewModel() {

--- a/app/src/main/java/com/w36495/randomrithm/ui/level/LevelListFragment.kt
+++ b/app/src/main/java/com/w36495/randomrithm/ui/level/LevelListFragment.kt
@@ -76,5 +76,14 @@ class LevelListFragment : Fragment(), LevelItemClickListener {
 
     companion object {
         const val TAG: String = "LevelListFragment"
+
+        fun newInstance(level: Int): Fragment {
+            val fragment = LevelListFragment()
+            fragment.arguments = Bundle().apply {
+                putInt("level", level)
+            }
+
+            return fragment
+        }
     }
 }

--- a/app/src/main/java/com/w36495/randomrithm/ui/level/LevelListFragment.kt
+++ b/app/src/main/java/com/w36495/randomrithm/ui/level/LevelListFragment.kt
@@ -20,7 +20,7 @@ class LevelListFragment : Fragment(), LevelItemClickListener {
     private var _binding: FragmentLevelListBinding? = null
     private val binding: FragmentLevelListBinding get() = _binding!!
 
-    private lateinit var levelViewModel: LevelViewModel
+    private lateinit var viewModel: LevelViewModel
     private lateinit var levelViewModelFactory: LevelViewModelFactory
     private lateinit var levelListAdapter: LevelListAdapter
 
@@ -37,8 +37,10 @@ class LevelListFragment : Fragment(), LevelItemClickListener {
         super.onViewCreated(view, savedInstanceState)
 
         setupViewModel()
-        levelViewModel.levels.observe(requireActivity()) {
-            setupListView(it)
+        setupListView()
+
+        viewModel.levels.observe(requireActivity()) {
+            levelListAdapter.setLevelList(it)
         }
     }
 
@@ -52,7 +54,7 @@ class LevelListFragment : Fragment(), LevelItemClickListener {
 
     private fun setupViewModel() {
         levelViewModelFactory = LevelViewModelFactory(GetLevelsUseCase(LevelRepositoryImpl(LevelRemoteDataSource(RetrofitClient.levelAPI))))
-        levelViewModel = ViewModelProvider(requireActivity(), levelViewModelFactory)[LevelViewModel::class.java]
+        viewModel = ViewModelProvider(requireActivity(), levelViewModelFactory)[LevelViewModel::class.java]
     }
 
     override fun onClickLevelItem(level: Int) {

--- a/app/src/main/java/com/w36495/randomrithm/ui/level/LevelListFragment.kt
+++ b/app/src/main/java/com/w36495/randomrithm/ui/level/LevelListFragment.kt
@@ -66,17 +66,13 @@ class LevelListFragment : Fragment(), LevelItemClickListener {
     }
 
     override fun onClickLevelItem(level: Int) {
-        val problemFragment = ProblemFragment().apply {
-            arguments = Bundle().apply {
-                putInt("level", level)
-            }
+        parentFragment?.let {
+            it.parentFragmentManager.beginTransaction()
+                .addToBackStack(ProblemFragment.TAG)
+                .setReorderingAllowed(true)
+                .replace(R.id.container_fragment, ProblemFragment.newInstance(level))
+                .commit()
         }
-
-        parentFragmentManager.beginTransaction()
-            .addToBackStack(ProblemFragment.TAG)
-            .setReorderingAllowed(true)
-            .replace(R.id.container_fragment, problemFragment)
-            .commit()
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/w36495/randomrithm/ui/level/LevelListFragment.kt
+++ b/app/src/main/java/com/w36495/randomrithm/ui/level/LevelListFragment.kt
@@ -8,7 +8,6 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import com.w36495.randomrithm.R
 import com.w36495.randomrithm.data.datasource.LevelRemoteDataSource
-import com.w36495.randomrithm.data.entity.LevelDTO
 import com.w36495.randomrithm.data.remote.RetrofitClient
 import com.w36495.randomrithm.databinding.FragmentLevelListBinding
 import com.w36495.randomrithm.domain.repository.LevelRepositoryImpl
@@ -42,14 +41,6 @@ class LevelListFragment : Fragment(), LevelItemClickListener {
         viewModel.levels.observe(requireActivity()) {
             levelListAdapter.setLevelList(it)
         }
-    }
-
-    private fun setupListView(levels: List<LevelDTO>) {
-        levelListAdapter = LevelListAdapter().apply {
-            setLevelList(levels)
-            setLevelItemClickListener(this@LevelListFragment)
-        }
-        binding.containerListview.adapter = levelListAdapter
     }
 
     private fun setupViewModel() {

--- a/app/src/main/java/com/w36495/randomrithm/ui/level/LevelListFragment.kt
+++ b/app/src/main/java/com/w36495/randomrithm/ui/level/LevelListFragment.kt
@@ -57,6 +57,14 @@ class LevelListFragment : Fragment(), LevelItemClickListener {
         viewModel = ViewModelProvider(requireActivity(), levelViewModelFactory)[LevelViewModel::class.java]
     }
 
+    private fun setupListView() {
+        levelListAdapter = LevelListAdapter().apply {
+            setLevelItemClickListener(this@LevelListFragment)
+        }
+
+        binding.containerListview.adapter = levelListAdapter
+    }
+
     override fun onClickLevelItem(level: Int) {
         val problemFragment = ProblemFragment().apply {
             arguments = Bundle().apply {

--- a/app/src/main/java/com/w36495/randomrithm/ui/level/LevelListFragment.kt
+++ b/app/src/main/java/com/w36495/randomrithm/ui/level/LevelListFragment.kt
@@ -10,7 +10,7 @@ import com.w36495.randomrithm.R
 import com.w36495.randomrithm.data.datasource.LevelRemoteDataSource
 import com.w36495.randomrithm.data.remote.RetrofitClient
 import com.w36495.randomrithm.databinding.FragmentLevelListBinding
-import com.w36495.randomrithm.domain.repository.LevelRepositoryImpl
+import com.w36495.randomrithm.data.repository.LevelRepositoryImpl
 import com.w36495.randomrithm.domain.usecase.GetLevelsUseCase
 import com.w36495.randomrithm.ui.problem.ProblemFragment
 import com.w36495.randomrithm.ui.viewmodel.LevelViewModelFactory

--- a/app/src/main/java/com/w36495/randomrithm/ui/level/LevelViewModel.kt
+++ b/app/src/main/java/com/w36495/randomrithm/ui/level/LevelViewModel.kt
@@ -13,14 +13,8 @@ class LevelViewModel(
     private val getLevelsUseCase: GetLevelsUseCase
 ) : ViewModel() {
     private var _levels = MutableLiveData<List<LevelDTO>>()
-    private var _menu = MutableLiveData(0)
 
     val levels: LiveData<List<LevelDTO>> get() = _levels
-    val menu: LiveData<Int> get() = _menu
-
-    fun changeMenu(selectMenu: Int) {
-        _menu.value = selectMenu
-    }
 
     fun getLevels(selectedLevel: Int) {
         viewModelScope.launch {

--- a/app/src/main/java/com/w36495/randomrithm/ui/level/LevelViewPagerAdapter.kt
+++ b/app/src/main/java/com/w36495/randomrithm/ui/level/LevelViewPagerAdapter.kt
@@ -1,0 +1,12 @@
+package com.w36495.randomrithm.ui.level
+
+import androidx.fragment.app.Fragment
+import androidx.viewpager2.adapter.FragmentStateAdapter
+
+class LevelViewPagerAdapter(fragment: Fragment) : FragmentStateAdapter(fragment) {
+    override fun getItemCount(): Int = 7
+
+    override fun createFragment(position: Int): Fragment {
+        return LevelListFragment.newInstance(position)
+    }
+}

--- a/app/src/main/java/com/w36495/randomrithm/ui/problem/ProblemFragment.kt
+++ b/app/src/main/java/com/w36495/randomrithm/ui/problem/ProblemFragment.kt
@@ -13,7 +13,7 @@ import com.w36495.randomrithm.data.remote.RetrofitClient
 import com.w36495.randomrithm.databinding.FragmentProblemBinding
 import com.w36495.randomrithm.domain.entity.Problem
 import com.w36495.randomrithm.domain.entity.Tag
-import com.w36495.randomrithm.domain.repository.ProblemRepositoryImpl
+import com.w36495.randomrithm.data.repository.ProblemRepositoryImpl
 import com.w36495.randomrithm.domain.usecase.GetProblemsByLevelUseCase
 import com.w36495.randomrithm.domain.usecase.GetProblemsByTagUseCase
 import com.w36495.randomrithm.ui.viewmodel.ProblemViewModelFactory

--- a/app/src/main/java/com/w36495/randomrithm/ui/tag/TagFragment.kt
+++ b/app/src/main/java/com/w36495/randomrithm/ui/tag/TagFragment.kt
@@ -11,7 +11,7 @@ import com.w36495.randomrithm.R
 import com.w36495.randomrithm.data.datasource.TagRemoteDataSource
 import com.w36495.randomrithm.data.remote.RetrofitClient
 import com.w36495.randomrithm.databinding.FragmentAlgorithmBinding
-import com.w36495.randomrithm.domain.repository.TagRepositoryImpl
+import com.w36495.randomrithm.data.repository.TagRepositoryImpl
 import com.w36495.randomrithm.domain.usecase.GetTagsUseCase
 import com.w36495.randomrithm.ui.problem.ProblemFragment
 import com.w36495.randomrithm.ui.viewmodel.TagViewModelFactory

--- a/app/src/main/res/layout/fragment_level.xml
+++ b/app/src/main/res/layout/fragment_level.xml
@@ -28,52 +28,15 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/layout_appbar"
-        app:tabMode="scrollable">
+        app:tabMode="scrollable" />
 
-        <com.google.android.material.tabs.TabItem
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Unrank" />
-
-        <com.google.android.material.tabs.TabItem
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="브론즈" />
-
-        <com.google.android.material.tabs.TabItem
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="실버" />
-
-        <com.google.android.material.tabs.TabItem
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="골드" />
-
-        <com.google.android.material.tabs.TabItem
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="플래티넘" />
-
-        <com.google.android.material.tabs.TabItem
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="다이아몬드" />
-
-        <com.google.android.material.tabs.TabItem
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="루비" />
-
-    </com.google.android.material.tabs.TabLayout>
-
-    <ListView
-        android:id="@+id/lv_levels"
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/container_viewpager"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/layout_tab"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/layout_tab" />
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## ISSUE
문제 목록을 위한 ViewPager2 적용하기 (#20)

## 수정된 내용
### TabLayout + ListView 로 작성되었던 부분을 TabLayout + ViewPager2 로 변경
**> 변경한 이유**
 사실 단순한 List 를 보여주는 것이기 때문에 ViewPager2 를 적용할 정도의 필요성을 못느꼈다. 
    ViewPager2 를 적용한다고해도 하나의 Fragment 를 통해 단순 List 를 보여주는 것이라 과한 것 아닌가? 하는 생각도 들었다.
 그리고 ViewPager2 를 사용하게되면 인스턴스를 1개만 생성하는 것이 아니라 TabLayout 의 TabItem 만큼 생성하고 사용하게 되는 것을 알았다. (아무리 재사용을 한다고하더라도, 1~2개의 인스턴스를 미리 만든다.) 
그런데! 단순한 ListView 로 작성되어있어서 ViewPager2 처럼 페이지를 옆으로 넘기는 전환 모션?이 없어서 밋밋해 보였음 .. !

## 결과
<img src="https://github.com/w36495/Randomrithm/assets/52291662/99cb101e-a0eb-4d90-8c4c-f561f50edab9" width=60%>
