### PR TITLE
[refactor/RANDOM-27] solved.ac 에서 제공하는 랜덤문제로 request 문 수정

### DIFF
--- a/app/src/main/java/com/w36495/randomrithm/data/remote/endpoints/ProblemAPI.kt
+++ b/app/src/main/java/com/w36495/randomrithm/data/remote/endpoints/ProblemAPI.kt
@@ -9,12 +9,16 @@ interface ProblemAPI {
     @GET("search/problem")
     suspend fun fetchProblemsByTag(
         @Query("query", encoded = true) query: String,
-        @Query("page") page: Int
+        @Query("page") page: Int,
+        @Query("sort") sort: String = "random",
+        @Query("direction") direction: String = "asc"
     ): Response<ProblemDTO>
 
     @GET("search/problem")
     suspend fun fetchProblemsByLevel(
         @Query("query", encoded = true) query: String,
-        @Query("page") page: Int
+        @Query("page") page: Int,
+        @Query("sort") sort: String = "random",
+        @Query("direction") direction: String = "asc"
     ): Response<ProblemDTO>
 }

--- a/app/src/main/java/com/w36495/randomrithm/ui/problem/ProblemFragment.kt
+++ b/app/src/main/java/com/w36495/randomrithm/ui/problem/ProblemFragment.kt
@@ -29,6 +29,7 @@ class ProblemFragment : Fragment() {
     private var currentTag: String? = null
     private var currentLevel: Int? = null
     private var currentProblems = emptyList<Problem>()
+    private var count: Int = 0
 
     private lateinit var levels: Array<String>
     private lateinit var levelBackgroundColors: IntArray
@@ -64,6 +65,7 @@ class ProblemFragment : Fragment() {
 
         problemViewModel.problems.observe(viewLifecycleOwner) {
             currentProblems = it.toList()
+            count = 0
 
             currentLevel?.let { getRandomProblemByLevel(it, currentProblems) }
             currentTag?.let { getRandomProblemByTag(it, currentProblems) }
@@ -93,17 +95,15 @@ class ProblemFragment : Fragment() {
 
     private fun getRandomProblemByLevel(currentLevel: Int, currentProblems: List<Problem>) {
         if (currentProblems.isNotEmpty() && currentProblems.all { it.level.toInt() == currentLevel }) {
-            val randomProblem = currentProblems.random()
-
-            showRandomProblem(randomProblem)
+            if (count >= currentProblems.size) problemViewModel.getProblemsByLevel(currentLevel)
+            else showRandomProblem(currentProblems[count++])
         }
     }
 
     private fun getRandomProblemByTag(currentTag: String, currentProblems: List<Problem>) {
         if (currentProblems.isNotEmpty() && currentProblems.all { problem -> problem.tags.any { it.key == currentTag } }) {
-            val randomProblem = currentProblems.random()
-
-            showRandomProblem(randomProblem)
+            if (count >= currentProblems.size) problemViewModel.getProblemsByTag(currentTag)
+            else showRandomProblem(currentProblems[count++])
         }
     }
 


### PR DESCRIPTION
## ISSUE
solved.ac 에서 제공하는 랜덤문제로 request 문 수정 (#27)

## 수정된 내용
### 수정 전
![스크린샷 2024-01-26 23 38 25](https://github.com/w36495/Randomrithm/assets/52291662/8d1ed6f3-740e-432d-bc1c-3c1716e5473e)

레벨/알고리즘에 대한 문제 목록을 가져올 때 **문제번호로 정렬된 페이지(총 50문제)** 를 가져왔다.
문제번호로 정렬된 페이지를 가져온 후, **random() 함수를 통해 50개 중 1개의 문제만 화면에 표시** 하였다.
만약 50번의 랜덤 문제를 모두 받아보았을 경우, 기존 50개의 문제가 아닌 새로운 50개의 문제를 요청하기 위해서는 page 를 증가시켜 다음 page 의 새로운 문제 목록을 가져와야 한다는 것이 번거롭다는 생각이 들었고 단점으로 인식되었다. 

### 수정 후
![스크린샷 2024-01-26 23 42 11](https://github.com/w36495/Randomrithm/assets/52291662/ce5cdd8c-3c83-44a0-9a50-954d1ebc4d90)

solved.ac 에서 제공하는 정렬 기능인 **`시프트 마음대로(sort=random)`** 를 사용하면 문제 번호로 정렬되지 않은 정말 랜덤의 문제들을 가져올 수 있다는 것을 알게되었다.
또한 50개의 문제를 받고나서도 **새로운 50문제가 필요할 때에도 page 를 증가시키지 않고 기존에 사용하던 request 요청 쿼리를 그대로 사용해도 새로운 문제 목록을 가져올 수 있다.**

50개의 문제들에 대해서 count 변수를 설정하였고, 1부터 50까지의 문제를 모두 받아 온 후 문제 목록의 총 개수를 넘어갔을 경우 새로운 문제 목록을 받아볼 수 있도록 수정하였다.
``` kotlin
if (count >= currentProblems.size) problemViewModel.getProblemsByLevel(currentLevel)
else showRandomProblem(currentProblems[count++])
```