### PR TITLE
[feat/RANDOM-26] 문제 화면에서 관련 알고리즘 클릭 시, 해당 알고리즘 문제로 이동

### DIFF
--- a/app/src/main/java/com/w36495/randomrithm/ui/problem/ProblemFragment.kt
+++ b/app/src/main/java/com/w36495/randomrithm/ui/problem/ProblemFragment.kt
@@ -121,9 +121,12 @@ class ProblemFragment : Fragment() {
     private fun showAlgorithmChips(chips: List<Tag>) {
         binding.layoutChip.removeAllViews()
 
-        chips.forEach {
+        chips.forEach {tag ->
             val chip = Chip(requireContext()).apply {
-                text = it.name
+                text = tag.name
+                this.setOnClickListener {
+                    showChangeProblemDialog(tag)
+                }
             }
             binding.layoutChip.addView(chip)
         }

--- a/app/src/main/java/com/w36495/randomrithm/ui/problem/ProblemFragment.kt
+++ b/app/src/main/java/com/w36495/randomrithm/ui/problem/ProblemFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import com.google.android.material.chip.Chip
@@ -128,6 +129,25 @@ class ProblemFragment : Fragment() {
         }
     }
 
+    private fun showChangeProblemDialog(tag: Tag) {
+        AlertDialog.Builder(requireContext())
+            .apply {
+                setTitle(getString(R.string.dialog_title_change_problem, tag.name))
+                setPositiveButton(getString(R.string.dialog_btn_okay)) { dialog, _ ->
+                    parentFragmentManager.beginTransaction()
+                        .addToBackStack(TAG)
+                        .setReorderingAllowed(true)
+                        .replace(R.id.container_fragment, newInstance(tag.key))
+                        .commit()
+
+                    dialog.dismiss()
+                }
+                setNeutralButton(getString(R.string.dialog_btn_cancel)) { dialog, _ ->
+                    dialog.dismiss()
+                }
+            }.show()
+    }
+
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
@@ -143,6 +163,16 @@ class ProblemFragment : Fragment() {
             }
 
             return problemFragment
+        }
+
+        fun newInstance(tag: String): Fragment {
+            val fragment = ProblemFragment().apply {
+                arguments = Bundle().apply {
+                    putString("tag", tag)
+                }
+            }
+
+            return fragment
         }
     }
 }

--- a/app/src/main/res/values-night/strings.xml
+++ b/app/src/main/res/values-night/strings.xml
@@ -1,5 +1,8 @@
 <resources>
     <string name="app_name">Randomrithm</string>
+    <string name="dialog_title_change_problem">%1$s 관련 랜덤 문제로 이동하시겠습니까?</string>
+    <string name="dialog_btn_okay">확인</string>
+    <string name="dialog_btn_cancel">취소</string>
 
     <string-array name="levelForTabItem">
         <item>Unrank</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,8 @@
 <resources>
     <string name="app_name">Randomrithm</string>
+    <string name="dialog_title_change_problem">%1$s 관련 랜덤 문제로 이동하시겠습니까?</string>
+    <string name="dialog_btn_okay">확인</string>
+    <string name="dialog_btn_cancel">취소</string>
 
     <string-array name="levelForTabItem">
         <item>Unrank</item>


### PR DESCRIPTION
## ISSUE
문제 화면에서 관련 알고리즘 클릭 시, 해당 알고리즘 문제로 이동 (#26)

## 구현 결과
|**`수정 전`**|**`수정 후`**|
|:--:|:--:|
|![2024-01-2623 04 42-ezgif com-video-to-gif-converter](https://github.com/w36495/Randomrithm/assets/52291662/89dc9c66-9e40-4028-9a25-8fd70a5f53fd)|![2024-01-2922 21 37-ezgif com-video-to-gif-converter](https://github.com/w36495/Randomrithm/assets/52291662/5da07fda-1b52-46bc-8ac5-4fe0eef177fd)|

## 고민한 부분
### 1️⃣ 관련 알고리즘 태그 클릭 -> 화면에 관련 문제 보여주기
- 구현 과정
viewModel 의 getProblemByTag() 를 통해 클릭한 tag 의 key 를 넘겨준다.
- 마주한 문제
level 을 선택해서 문제가 보여진 경우, 새로운 문제를 위해 currentLevel 의 값을 null 로 변경 -> viewModel 을 통해 데이터를 가져와야 한다.
하지만 viewModel 을 통해 데이터를 가져왔을 때, **level 을 통해 문제를 표시하는 것** 인지 or **tag 를 클릭해서 문제를 표시하는 것인지** 에 대한 확인을 아래와 같이 null 로 체크하도록 구현해놓았다.
``` kotlin
currentLevel?.let { getRandomProblemByLevel(it, currentProblems) }
currentTag?.let { getRandomProblemByTag(it, currentProblems) }
```
하지만 viewModel 로 새로운 데이터를 가져온 후 -> currentLevel 의 값이 null 로 변경됨을 알게 되었다.  

- 해당 과정에 대한 나의 예상
currentLevel = null 변경 -> viewModel 의 getRandomProblemByTag() -> 새로운 데이터 화면에 보여짐
- 실제 과정
viewModel 의 getRandomProblelmByTag() -> 위의 null 체크 코드가 실행되지 않음 (currentLevel != null && currentTag != null) -> 기존의 랜덤 문제 표시(새로운 문제 목록 표시X) -> currentLevel = null 변경

그리고 관련 알고리즘 태그를 실수로 눌렀을 경우, 바로 화면이 넘어간다면 이전의 문제를 다시 확인할 수 있는 방법이 없다!고 생각이 되었고
이를 방지하기 위해 아래의 방법과 같이 다이얼로그를 통해 실수로 클릭이 된 것인지, 의도해서 클릭한 것인지를 체크하고자 하였다.

### 2️⃣ 관련 알고리즘 태그 클릭 -> 화면 전환 여부 다이얼로그 표시 -> 화면에 문제 보여주기
- 구현 의도
관련 알고리즘 태그를 클릭하면 다이얼로그를 통해 실수로 클릭되었는지, 의도된 액션이었는지 판별한다.
1) 실수로 클릭하였다면, '취소' 버튼을 통해 기존 화면으로 돌아온다.
2) 의도된 액션이라면, '확인' 버튼을 통해 관련 알고리즘 랜덤 문제를 화면에 보여준다.
기존의 문제로 다시 돌아올 경우를 위해 새 인스턴스를 생성하여 FragmentManager 를 통해 화면을 전환시켰다.

다만, back 버튼을 통해 이전 화면으로 돌아왔을 때 다시 랜덤의 문제가 보여지므로 기존 문제에 대한 정보를 기억해놓고 있으면 좋을 것 같다!
