### PR TITLE
[refactor/RANDOM-31] 뒤로가기를 통해 이전 문제로 돌아온 경우, 기존의 문제 그대로 화면에 표시

### DIFF
--- a/app/src/main/java/com/w36495/randomrithm/ui/level/LevelListFragment.kt
+++ b/app/src/main/java/com/w36495/randomrithm/ui/level/LevelListFragment.kt
@@ -69,7 +69,7 @@ class LevelListFragment : Fragment(), LevelItemClickListener {
             it.parentFragmentManager.beginTransaction()
                 .addToBackStack(ProblemFragment.TAG)
                 .setReorderingAllowed(true)
-                .replace(R.id.container_fragment, ProblemFragment.newInstance(level))
+                .replace(R.id.container_fragment, ProblemFragment.newInstance(ProblemFragment.INSTANCE_LEVEL, level))
                 .commit()
         }
     }

--- a/app/src/main/java/com/w36495/randomrithm/ui/problem/ProblemFragment.kt
+++ b/app/src/main/java/com/w36495/randomrithm/ui/problem/ProblemFragment.kt
@@ -18,6 +18,7 @@ import com.w36495.randomrithm.data.repository.ProblemRepositoryImpl
 import com.w36495.randomrithm.domain.usecase.GetProblemsByLevelUseCase
 import com.w36495.randomrithm.domain.usecase.GetProblemsByTagUseCase
 import com.w36495.randomrithm.ui.viewmodel.ProblemViewModelFactory
+import com.w36495.randomrithm.utils.putValue
 
 class ProblemFragment : Fragment() {
 
@@ -150,7 +151,7 @@ class ProblemFragment : Fragment() {
                     parentFragmentManager.beginTransaction()
                         .addToBackStack(TAG)
                         .setReorderingAllowed(true)
-                        .replace(R.id.container_fragment, newInstance(tag.key))
+                        .replace(R.id.container_fragment, newInstance(INSTANCE_TAG, tag.key))
                         .commit()
 
                     dialog.dismiss()
@@ -168,24 +169,13 @@ class ProblemFragment : Fragment() {
 
     companion object {
         const val TAG: String = "ProblemFragment"
-        fun newInstance(level: Int): Fragment {
-            val problemFragment = ProblemFragment().apply {
-                arguments = Bundle().apply {
-                    putInt("level", level)
-                }
+        const val INSTANCE_TAG: String = "tag"
+        const val INSTANCE_LEVEL: String = "level"
+
+        fun <T> newInstance(tag: String, value: T): Fragment {
+            return ProblemFragment().apply {
+                arguments = Bundle().putValue(tag, value)
             }
-
-            return problemFragment
-        }
-
-        fun newInstance(tag: String): Fragment {
-            val fragment = ProblemFragment().apply {
-                arguments = Bundle().apply {
-                    putString("tag", tag)
-                }
-            }
-
-            return fragment
         }
     }
 }

--- a/app/src/main/java/com/w36495/randomrithm/ui/problem/ProblemFragment.kt
+++ b/app/src/main/java/com/w36495/randomrithm/ui/problem/ProblemFragment.kt
@@ -94,6 +94,8 @@ class ProblemFragment : Fragment() {
 
     private fun setupButtonClickEvent() {
         binding.btnNextProblem.setOnClickListener {
+            if (problemViewModel.hasSavedProblem()) problemViewModel.clearSavedProblem()
+
             currentLevel?.let { getRandomProblemByLevel(it, currentProblems) }
             currentTag?.let { getRandomProblemByTag(it, currentProblems) }
         }
@@ -108,6 +110,7 @@ class ProblemFragment : Fragment() {
     private fun getRandomProblemByLevel(currentLevel: Int, currentProblems: List<Problem>) {
         if (currentProblems.isNotEmpty() && currentProblems.all { it.level.toInt() == currentLevel }) {
             if (count >= currentProblems.size) problemViewModel.getProblemsByLevel(currentLevel)
+            else if (problemViewModel.hasSavedProblem()) showRandomProblem(problemViewModel.getSavedProblem())
             else showRandomProblem(currentProblems[count++])
         }
     }
@@ -115,6 +118,7 @@ class ProblemFragment : Fragment() {
     private fun getRandomProblemByTag(currentTag: String, currentProblems: List<Problem>) {
         if (currentProblems.isNotEmpty() && currentProblems.all { problem -> problem.tags.any { it.key == currentTag } }) {
             if (count >= currentProblems.size) problemViewModel.getProblemsByTag(currentTag)
+            else if (problemViewModel.hasSavedProblem()) showRandomProblem(problemViewModel.getSavedProblem())
             else showRandomProblem(currentProblems[count++])
         }
     }
@@ -148,6 +152,8 @@ class ProblemFragment : Fragment() {
             .apply {
                 setTitle(getString(R.string.dialog_title_change_problem, tag.name))
                 setPositiveButton(getString(R.string.dialog_btn_okay)) { dialog, _ ->
+                    problemViewModel.saveCurrentProblem(currentProblems[count-1])
+
                     parentFragmentManager.beginTransaction()
                         .addToBackStack(TAG)
                         .setReorderingAllowed(true)

--- a/app/src/main/java/com/w36495/randomrithm/ui/problem/ProblemViewModel.kt
+++ b/app/src/main/java/com/w36495/randomrithm/ui/problem/ProblemViewModel.kt
@@ -16,12 +16,29 @@ class ProblemViewModel(
     private val getProblemsByLevelUseCase: GetProblemsByLevelUseCase,
     private val getProblemsByTagUseCase: GetProblemsByTagUseCase
 ) : ViewModel() {
+    private var savedProblem: Problem? = null
+
     private val _problems = MutableLiveData<List<Problem>>()
     private val _loading = MutableLiveData(false)
     val problems: LiveData<List<Problem>>
         get() = _problems
     val loading: LiveData<Boolean>
         get() = _loading
+
+    fun getSavedProblem(): Problem {
+        _loading.value = false
+        return this.savedProblem!!
+    }
+
+    fun saveCurrentProblem(problem: Problem) {
+        this.savedProblem = problem
+    }
+
+    fun hasSavedProblem(): Boolean = savedProblem != null
+
+    fun clearSavedProblem() {
+        this.savedProblem = null
+    }
 
     fun getProblemsByTag(tagKey: String) {
         val requestQuery = "solvable:true+tag:$tagKey"

--- a/app/src/main/java/com/w36495/randomrithm/ui/tag/TagFragment.kt
+++ b/app/src/main/java/com/w36495/randomrithm/ui/tag/TagFragment.kt
@@ -68,16 +68,10 @@ class TagFragment : Fragment(), TagClickListener {
     }
 
     override fun onClickTagItem(tagKey: String) {
-        val problemFragment = ProblemFragment().apply {
-            arguments = Bundle().apply {
-                this.putString("tag", tagKey)
-            }
-        }
-
         parentFragmentManager.beginTransaction()
             .addToBackStack(ProblemFragment.TAG)
             .setReorderingAllowed(true)
-            .replace(R.id.container_fragment, problemFragment)
+            .replace(R.id.container_fragment, ProblemFragment.newInstance(ProblemFragment.INSTANCE_TAG, tagKey))
             .commit()
     }
 

--- a/app/src/main/java/com/w36495/randomrithm/utils/extentions.kt
+++ b/app/src/main/java/com/w36495/randomrithm/utils/extentions.kt
@@ -1,5 +1,6 @@
 package com.w36495.randomrithm.utils
 
+import android.os.Bundle
 import com.w36495.randomrithm.data.entity.LevelDTO
 
 fun List<LevelDTO>.sortedByLevel(start: Int, end: Int): List<LevelDTO> {
@@ -7,5 +8,12 @@ fun List<LevelDTO>.sortedByLevel(start: Int, end: Int): List<LevelDTO> {
         this.filter { it.level == 0 }.sortedByDescending { it.level }
     } else {
         this.filter { it.level in start..end }.sortedByDescending { it.level }
+    }
+}
+
+fun <T> Bundle.putValue(tag: String, value: T): Bundle {
+    return this.apply {
+        if (value is Int) putInt(tag, value)
+        else if (value is String) putString(tag, value)
     }
 }


### PR DESCRIPTION
## ISSUE
뒤로가기를 통해 이전 문제로 돌아온 경우, 기존의 문제 그대로 화면에 표시 (#31 )

## 구현 결과
|**`수정 전`**|**`수정 후`**|
|:--:|:--:|
|![수정전](https://github.com/w36495/Randomrithm/assets/52291662/55864d9b-1f12-4390-a69e-1229dd53ef71)|![수정후](https://github.com/w36495/Randomrithm/assets/52291662/6cfd9d40-0cc6-42f5-a6ab-d46e69c99a00)|
|뒤로가기 클릭 시, 기존 문제(24380)가 화면에 보여지지 않음|뒤로가기 클릭 시, 기존 문제(23910)가 화면에 보여짐|

## 구현 과정