### PR TITLE
[refactor/RANDOM-59] 문제 화면 관련 리팩토링

### DIFF
--- a/app/src/main/java/com/w36495/randomrithm/data/message/ExceptionMessage.kt
+++ b/app/src/main/java/com/w36495/randomrithm/data/message/ExceptionMessage.kt
@@ -1,0 +1,5 @@
+package com.w36495.randomrithm.data.message
+
+enum class ExceptionMessage(message: String) {
+    NonExistProblem("문제가 존재하지 않습니다.")
+}

--- a/app/src/main/java/com/w36495/randomrithm/domain/usecase/GetProblemsUseCase.kt
+++ b/app/src/main/java/com/w36495/randomrithm/domain/usecase/GetProblemsUseCase.kt
@@ -1,5 +1,6 @@
 package com.w36495.randomrithm.domain.usecase
 
+import com.w36495.randomrithm.data.message.ExceptionMessage
 import com.w36495.randomrithm.domain.entity.Problem
 import com.w36495.randomrithm.domain.entity.Tag
 import com.w36495.randomrithm.domain.repository.ProblemRepository
@@ -16,6 +17,9 @@ class GetProblemsUseCase @Inject constructor(
 
         if (result.isSuccessful) {
             result.body()?.let { dto ->
+                if (dto.count == 0) {
+                    throw IllegalStateException(ExceptionMessage.NonExistProblem.name)
+                }
                 dto.items.forEach {
                     val tags = mutableListOf<Tag>()
                     it.tags.forEach { tag ->

--- a/app/src/main/java/com/w36495/randomrithm/ui/problem/ProblemFragment.kt
+++ b/app/src/main/java/com/w36495/randomrithm/ui/problem/ProblemFragment.kt
@@ -62,8 +62,8 @@ class ProblemFragment : Fragment() {
         }
 
         currentTag?.let { tag ->
-            currentLevel?.let {  level ->
-                if (level == -1) problemViewModel.getProblemsByTag(tag)
+            currentLevel?.let { level ->
+                if (level == All_LEVEL) { problemViewModel.getProblemsByTag(tag) }
                 else problemViewModel.getProblemByTagAndLevel(tag, level)
             }
         } ?: currentLevel?.let { level ->
@@ -79,9 +79,12 @@ class ProblemFragment : Fragment() {
             count = 0
 
             currentTag?.let { tag ->
-                currentLevel?.let {  level ->
-                    if (level == -1) getRandomProblems { problemViewModel.getProblemsByTag(tag) }
-                    else getRandomProblems { problemViewModel.getProblemByTagAndLevel(tag, level) }
+                currentLevel?.let { level ->
+                    if (level == All_LEVEL) {
+                        getRandomProblems { problemViewModel.getProblemsByTag(tag) }
+                    } else {
+                        getRandomProblems { problemViewModel.getProblemByTagAndLevel(tag, level) }
+                    }
                 }
             } ?: currentLevel?.let { level ->
                 getRandomProblems { problemViewModel.getProblemsByLevel(level) }
@@ -142,8 +145,11 @@ class ProblemFragment : Fragment() {
 
             currentTag?.let { tag ->
                 currentLevel?.let {  level ->
-                    if (level == -1) getRandomProblems { problemViewModel.getProblemsByTag(tag) }
-                    else getRandomProblems { problemViewModel.getProblemByTagAndLevel(tag, level) }
+                    if (level == All_LEVEL) {
+                        getRandomProblems { problemViewModel.getProblemsByTag(tag) }
+                    } else {
+                        getRandomProblems { problemViewModel.getProblemByTagAndLevel(tag, level) }
+                    }
                 }
             } ?: currentLevel?.let { level ->
                 getRandomProblems { problemViewModel.getProblemsByLevel(level) }
@@ -211,7 +217,7 @@ class ProblemFragment : Fragment() {
                     parentFragmentManager.beginTransaction()
                         .addToBackStack(TAG)
                         .setReorderingAllowed(true)
-                        .replace(R.id.container_fragment, newInstance(INSTANCE_TAG, tag.key))
+                        .replace(R.id.container_fragment, newInstance(INSTANCE_TAG, tag.key, INSTANCE_LEVEL, All_LEVEL))
                         .commit()
 
                     dialog.dismiss()
@@ -236,6 +242,7 @@ class ProblemFragment : Fragment() {
 
     companion object {
         private const val BASE_URL: String = "https://www.acmicpc.net/problem/"
+        private const val All_LEVEL: Int = -1
         const val TAG: String = "ProblemFragment"
         const val INSTANCE_TAG: String = "tag"
         const val INSTANCE_LEVEL: String = "level"

--- a/app/src/main/java/com/w36495/randomrithm/ui/problem/ProblemFragment.kt
+++ b/app/src/main/java/com/w36495/randomrithm/ui/problem/ProblemFragment.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -102,6 +103,13 @@ class ProblemFragment : Fragment() {
             } else {
                 binding.layoutShimmer.stopShimmer()
                 binding.layoutShimmer.visibility = View.INVISIBLE
+            }
+        }
+
+        problemViewModel.error.observe(viewLifecycleOwner) {
+            if (!it.equals("")) {
+                Toast.makeText(requireContext(), it, Toast.LENGTH_SHORT).show()
+                parentFragmentManager.popBackStack()
             }
         }
 

--- a/app/src/main/java/com/w36495/randomrithm/ui/problem/ProblemViewModel.kt
+++ b/app/src/main/java/com/w36495/randomrithm/ui/problem/ProblemViewModel.kt
@@ -1,6 +1,5 @@
 package com.w36495.randomrithm.ui.problem
 
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -23,11 +22,9 @@ class ProblemViewModel @Inject constructor(
 
     private val _problems = MutableLiveData<List<Problem>>()
     private val _loading = MutableLiveData(false)
-    val problems: LiveData<List<Problem>>
-        get() = _problems
-    val loading: LiveData<Boolean>
-        get() = _loading
 
+    val problems: LiveData<List<Problem>> get() = _problems
+    val loading: LiveData<Boolean> get() = _loading
     val tagState: Flow<Boolean> = getTagStateUseCase.invoke()
 
     fun getSavedProblem(): Problem {
@@ -55,58 +52,25 @@ class ProblemViewModel @Inject constructor(
             else -> "r"
         }
         val query = "%23$tag+*$replaceLevel"
-
-        viewModelScope.launch {
-            try {
-                _loading.value = true
-                delay(500)
-
-                _problems.value = getProblemsUseCase.invoke(query)
-            } catch (exception: Exception) {
-                exception.localizedMessage?.let { Log.d(TAG, it) } ?: Log.d(TAG, "error message == null")
-            } finally {
-                _loading.value = false
-            }
-        }
+        getProblems(query)
     }
 
     fun getProblemsByTag(tagKey: String) {
         val query = "tag:$tagKey"
-
-        viewModelScope.launch {
-            try {
-                _loading.value = true
-                delay(500)
-
-                _problems.value = getProblemsUseCase.invoke(query)
-            } catch (exception: Exception) {
-                exception.localizedMessage?.let { Log.d(TAG, it) } ?: Log.d(TAG, "error message == null")
-            } finally {
-                _loading.value = false
-            }
-        }
+        getProblems(query)
     }
 
     fun getProblemsByLevel(level: Int) {
         val query = "tier:$level"
-
-        viewModelScope.launch {
-            try {
-                _loading.value = true
-                delay(500)
-
-                _problems.value = getProblemsUseCase.invoke(query)
-            } catch (exception: Exception) {
-                Log.d(TAG, exception.localizedMessage)
-            } finally {
-                _loading.value = false
-            }
-        }
+        getProblems(query)
     }
 
     fun getProblemsBySourceOfProblem(selectedSource: String) {
         val query = "%2F$selectedSource"
+        getProblems(query)
+    }
 
+    private fun getProblems(query: String) {
         viewModelScope.launch {
             try {
                 _loading.value = true
@@ -114,12 +78,11 @@ class ProblemViewModel @Inject constructor(
 
                 _problems.value = getProblemsUseCase.invoke(query)
             } catch (exception: Exception) {
-
+                _error.value = exception.message
             } finally {
                 _loading.value = false
             }
         }
-
     }
 
     companion object {

--- a/app/src/main/java/com/w36495/randomrithm/ui/problem/ProblemViewModel.kt
+++ b/app/src/main/java/com/w36495/randomrithm/ui/problem/ProblemViewModel.kt
@@ -22,9 +22,11 @@ class ProblemViewModel @Inject constructor(
 
     private val _problems = MutableLiveData<List<Problem>>()
     private val _loading = MutableLiveData(false)
+    private val _error = MutableLiveData("")
 
     val problems: LiveData<List<Problem>> get() = _problems
     val loading: LiveData<Boolean> get() = _loading
+    val error: LiveData<String> get() = _error
     val tagState: Flow<Boolean> = getTagStateUseCase.invoke()
 
     fun getSavedProblem(): Problem {

--- a/app/src/main/res/layout/fragment_source.xml
+++ b/app/src/main/res/layout/fragment_source.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="#FCFCFC">
+    android:background="@color/white">
 
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/layout_appbar"
@@ -34,13 +34,13 @@
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingHorizontal="16dp">
+            android:layout_height="wrap_content">
 
             <androidx.cardview.widget.CardView
                 android:id="@+id/card_camp"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
+                android:layout_marginHorizontal="16dp"
                 android:layout_marginTop="8dp"
                 app:cardCornerRadius="15dp"
                 app:layout_constraintEnd_toEndOf="parent"
@@ -75,6 +75,7 @@
                 android:id="@+id/card_high_school"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
+                android:layout_marginHorizontal="16dp"
                 android:layout_marginTop="12dp"
                 app:cardCornerRadius="15dp"
                 app:layout_constraintEnd_toEndOf="parent"
@@ -109,6 +110,7 @@
                 android:id="@+id/card_icpc"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
+                android:layout_marginHorizontal="16dp"
                 android:layout_marginTop="12dp"
                 app:cardCornerRadius="15dp"
                 app:layout_constraintEnd_toEndOf="parent"
@@ -143,6 +145,7 @@
                 android:id="@+id/card_olympiad"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
+                android:layout_marginHorizontal="16dp"
                 android:layout_marginTop="12dp"
                 app:cardCornerRadius="15dp"
                 app:layout_constraintEnd_toEndOf="parent"
@@ -177,6 +180,7 @@
                 android:id="@+id/card_university"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
+                android:layout_marginHorizontal="16dp"
                 android:layout_marginTop="12dp"
                 android:layout_marginBottom="16dp"
                 app:cardCornerRadius="15dp"


### PR DESCRIPTION
## ISSUE
문제 화면 관련 리팩토링 (#59 )

## 수정한 부분
1. ProblemFragment 의 arguments 조건문 수정
2. 태그(알고리즘)만 선택했을 경우, level 값을 -1 (전체 문제)으로 기본값 설정
3. 문제가 존재하지 않는 경우에 대한 예외 처리 및 토스트 표시
4. ProblemViewModel 내에서 중복되어있던 코드를 1개의 함수로 빼내기
```kotlin
private fun getProblems(query: String) {
    viewModelScope.launch {
        try {
            _loading.value = true
            delay(500)

            _problems.value = getProblemsUseCase.invoke(query)
        } catch (exception: Exception) {
            _error.value = exception.message
        } finally {
            _loading.value = false
        }
    }
}
```
5. 출처 화면의 각 버튼 margin 수정