### PR TITLE
[feat/RANDOM-64] 아이디 기억하기

### DIFF
--- a/app/src/main/java/com/w36495/randomrithm/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/w36495/randomrithm/data/repository/UserRepositoryImpl.kt
@@ -3,7 +3,6 @@ package com.w36495.randomrithm.data.repository
 import com.w36495.randomrithm.data.datasource.UserRemoteDataSource
 import com.w36495.randomrithm.data.entity.UserInfoDTO
 import com.w36495.randomrithm.domain.repository.UserRepository
-import retrofit2.Response
 import javax.inject.Inject
 
 class UserRepositoryImpl @Inject constructor(
@@ -29,7 +28,16 @@ class UserRepositoryImpl @Inject constructor(
 
         return false
     }
-    override suspend fun getUserInfo(userId: String): Response<UserInfoDTO> {
-        return userRemoteDataSource.getUserInfo(userId)
+    override suspend fun getUserInfo(userId: String): Boolean {
+        val result = userRemoteDataSource.getUserInfo(userId)
+
+        if (result.isSuccessful) {
+            result.body()?.let {
+                user = it
+                return true
+            }
+        }
+
+        return false
     }
 }

--- a/app/src/main/java/com/w36495/randomrithm/di/UseCaseModule.kt
+++ b/app/src/main/java/com/w36495/randomrithm/di/UseCaseModule.kt
@@ -3,6 +3,8 @@ package com.w36495.randomrithm.di
 import android.content.Context
 import com.w36495.randomrithm.domain.usecase.ChangeTagStateUseCase
 import com.w36495.randomrithm.domain.usecase.GetTagStateUseCase
+import com.w36495.randomrithm.domain.usecase.LoadUserIdUseCase
+import com.w36495.randomrithm.domain.usecase.SaveUserIdUseCase
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -21,4 +23,14 @@ object UseCaseModule {
     fun provideChangeTagStateUseCase(
         @ApplicationContext context: Context
     ): ChangeTagStateUseCase = ChangeTagStateUseCase(context)
+
+    @Provides
+    fun provideSaveUserIdUseCase(
+        @ApplicationContext context: Context
+    ): SaveUserIdUseCase = SaveUserIdUseCase(context)
+
+    @Provides
+    fun provideLoadUserIdUseCase(
+        @ApplicationContext context: Context
+    ): LoadUserIdUseCase = LoadUserIdUseCase(context)
 }

--- a/app/src/main/java/com/w36495/randomrithm/domain/repository/UserRepository.kt
+++ b/app/src/main/java/com/w36495/randomrithm/domain/repository/UserRepository.kt
@@ -1,11 +1,9 @@
 package com.w36495.randomrithm.domain.repository
 
-import com.w36495.randomrithm.data.entity.UserDTO
 import com.w36495.randomrithm.data.entity.UserInfoDTO
-import retrofit2.Response
 
 interface UserRepository {
     fun getCachedUserInfo(): UserInfoDTO?
     suspend fun getUser(query: String): Boolean
-    suspend fun getUserInfo(userId: String): Response<UserInfoDTO>
+    suspend fun getUserInfo(userId: String): Boolean
 }

--- a/app/src/main/java/com/w36495/randomrithm/domain/usecase/GetSolvableProblemsUseCase.kt
+++ b/app/src/main/java/com/w36495/randomrithm/domain/usecase/GetSolvableProblemsUseCase.kt
@@ -8,10 +8,10 @@ class GetSolvableProblemsUseCase @Inject constructor(
     private val getProblemsUseCase: GetProblemsUseCase,
     private val getSolvedProblemsUseCase: GetSolvedProblemsUseCase,
 ) {
-    suspend operator fun invoke(userId: String, problemType: ProblemType): List<Problem> {
+    suspend operator fun invoke(problemType: ProblemType): List<Problem> {
         val solvableProblems = mutableListOf<Problem>()
         val problems = getProblemsUseCase(problemType)
-        val solvedProblems = getSolvedProblemsUseCase(userId)
+        val solvedProblems = getSolvedProblemsUseCase()
 
         problems.forEach { problem ->
             if (isSolvableProblem(problem, solvedProblems)) solvableProblems.addAll(problems)

--- a/app/src/main/java/com/w36495/randomrithm/domain/usecase/GetSolvedProblemsUseCase.kt
+++ b/app/src/main/java/com/w36495/randomrithm/domain/usecase/GetSolvedProblemsUseCase.kt
@@ -11,21 +11,13 @@ class GetSolvedProblemsUseCase @Inject constructor(
     private val userRepository: UserRepository,
     private val problemRepository: ProblemRepository
 ) {
-    suspend operator fun invoke(userId: String): List<Problem> {
-        return getUserInfo(userId)
+    suspend operator fun invoke(): List<Problem> {
+        return getUserInfo()
     }
 
-    private suspend fun getUserInfo(userId: String): List<Problem> {
-        val result = userRepository.getUserInfo(userId)
-        if (result.isSuccessful) {
-            result.body()?.let { dto ->
-                dto.toDomainModel().also { user ->
-                    return getSolvedProblems(user.id, user.solvedCount)
-                }
-            }
-        }
-
-        return emptyList()
+    private suspend fun getUserInfo(): List<Problem> {
+        val user = userRepository.getCachedUserInfo()!!.toDomainModel()
+        return getSolvedProblems(user.id, user.solvedCount)
     }
 
     private suspend fun getSolvedProblems(userId: String, solvedProblemCount: Int): List<Problem> {

--- a/app/src/main/java/com/w36495/randomrithm/domain/usecase/HasCacheUserInfoUseCase.kt
+++ b/app/src/main/java/com/w36495/randomrithm/domain/usecase/HasCacheUserInfoUseCase.kt
@@ -1,0 +1,12 @@
+package com.w36495.randomrithm.domain.usecase
+
+import com.w36495.randomrithm.domain.repository.UserRepository
+import javax.inject.Inject
+
+class HasCacheUserInfoUseCase @Inject constructor(
+    private val userRepository: UserRepository,
+) {
+    operator fun invoke(): Boolean {
+        return userRepository.getCachedUserInfo()?.let { true } ?: false
+    }
+}

--- a/app/src/main/java/com/w36495/randomrithm/domain/usecase/LoadUserIdUseCase.kt
+++ b/app/src/main/java/com/w36495/randomrithm/domain/usecase/LoadUserIdUseCase.kt
@@ -1,0 +1,18 @@
+package com.w36495.randomrithm.domain.usecase
+
+import android.content.Context
+import com.w36495.randomrithm.domain.usecase.SaveUserIdUseCase.Companion.USER_ID_KEY
+import com.w36495.randomrithm.domain.usecase.SaveUserIdUseCase.Companion.dataStoreForUser
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class LoadUserIdUseCase @Inject constructor(
+    private val context: Context
+) {
+    operator fun invoke(): Flow<String?> {
+        return context.dataStoreForUser.data.map {
+            it[USER_ID_KEY]
+        }
+    }
+}

--- a/app/src/main/java/com/w36495/randomrithm/domain/usecase/SaveUserIdUseCase.kt
+++ b/app/src/main/java/com/w36495/randomrithm/domain/usecase/SaveUserIdUseCase.kt
@@ -1,0 +1,24 @@
+package com.w36495.randomrithm.domain.usecase
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import javax.inject.Inject
+
+class SaveUserIdUseCase @Inject constructor(
+    private val context: Context
+) {
+    suspend operator fun invoke(userId: String) {
+        context.dataStoreForUser.edit {
+            it[USER_ID_KEY] = userId
+        }
+    }
+
+    companion object {
+        val Context.dataStoreForUser: DataStore<Preferences> by preferencesDataStore(name = "user")
+        val USER_ID_KEY = stringPreferencesKey("userId")
+    }
+}

--- a/app/src/main/java/com/w36495/randomrithm/domain/usecase/SetCacheUserIdUseCase.kt
+++ b/app/src/main/java/com/w36495/randomrithm/domain/usecase/SetCacheUserIdUseCase.kt
@@ -1,0 +1,12 @@
+package com.w36495.randomrithm.domain.usecase
+
+import com.w36495.randomrithm.domain.repository.UserRepository
+import javax.inject.Inject
+
+class SetCacheUserIdUseCase @Inject constructor(
+    private val userRepository: UserRepository,
+) {
+    suspend operator fun invoke(userId: String): Boolean {
+        return userRepository.getUserInfo(userId)
+    }
+}

--- a/app/src/main/java/com/w36495/randomrithm/presentation/home/HomeFragment.kt
+++ b/app/src/main/java/com/w36495/randomrithm/presentation/home/HomeFragment.kt
@@ -22,6 +22,7 @@ import com.w36495.randomrithm.domain.entity.User
 import com.w36495.randomrithm.utils.putProblemType
 import com.w36495.randomrithm.utils.showShortToast
 import dagger.hilt.android.AndroidEntryPoint
+
 @AndroidEntryPoint
 class HomeFragment : Fragment(), PopularAlgorithmClickListener {
     private var _binding: FragmentHomeBinding? = null
@@ -40,7 +41,6 @@ class HomeFragment : Fragment(), PopularAlgorithmClickListener {
         savedInstanceState: Bundle?,
     ): View? {
         _binding = FragmentHomeBinding.inflate(inflater, container, false)
-        homeViewModel.getUserInfo()?.let { setupUserProfile(it) }
 
         return binding.root
     }
@@ -58,16 +58,13 @@ class HomeFragment : Fragment(), PopularAlgorithmClickListener {
         super.onViewCreated(view, savedInstanceState)
 
         subscribeUi()
+        setupUserProfile(homeViewModel.user)
         setupPopularAlgorithm()
         setupButtons()
     }
 
     private fun subscribeUi() {
         with(homeViewModel) {
-            user.observe(viewLifecycleOwner) { user ->
-                setupUserProfile(user)
-            }
-
             error.observe(viewLifecycleOwner) { message ->
                 requireContext().showShortToast(message)
             }

--- a/app/src/main/java/com/w36495/randomrithm/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/w36495/randomrithm/presentation/home/HomeViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.w36495.randomrithm.domain.entity.Tag
-import com.w36495.randomrithm.domain.entity.User
 import com.w36495.randomrithm.domain.usecase.GetCachedUserInfoUseCase
 import com.w36495.randomrithm.domain.usecase.GetTagsUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -19,11 +18,9 @@ class HomeViewModel @Inject constructor(
 ) : ViewModel() {
     private var _error = MutableLiveData<String>()
     private var _tags = MutableLiveData<List<Tag>>()
-    private var _user = MutableLiveData<User>()
-
-    val user: LiveData<User> get() = _user
     val tags: LiveData<List<Tag>> get() = _tags
     val error: LiveData<String> get() = _error
+    val user = getCachedUserInfoUseCase()
 
     init {
         loadInitData()
@@ -33,17 +30,5 @@ class HomeViewModel @Inject constructor(
         viewModelScope.launch {
             _tags.value = getTagsUseCase.invoke().subList(0, 10)
         }
-    }
-
-    fun getUserInfo(): User? {
-        var user: User? = null
-
-        try {
-            user = getCachedUserInfoUseCase()
-        } catch (exception: Exception) {
-            _error.value = exception.message.toString()
-        }
-
-        return user
     }
 }

--- a/app/src/main/java/com/w36495/randomrithm/presentation/login/LoginFragment.kt
+++ b/app/src/main/java/com/w36495/randomrithm/presentation/login/LoginFragment.kt
@@ -71,6 +71,8 @@ class LoginFragment : Fragment() {
                 val inputId = binding.etId.text.toString()
 
                 if (inputId == loginViewModel.getUserId()) {
+                    if (binding.cbSaveUserId.isChecked) { loginViewModel.saveUserId(inputId) }
+
                     requireContext().showShortToast(Constants.LOGIN_SUCCESS.message)
                     moveHomeActivity()
                 } else {

--- a/app/src/main/java/com/w36495/randomrithm/presentation/login/LoginViewModel.kt
+++ b/app/src/main/java/com/w36495/randomrithm/presentation/login/LoginViewModel.kt
@@ -6,7 +6,11 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.w36495.randomrithm.domain.usecase.CheckUserIdUseCase
 import com.w36495.randomrithm.domain.usecase.GetCachedUserInfoUseCase
+import com.w36495.randomrithm.domain.usecase.LoadUserIdUseCase
+import com.w36495.randomrithm.domain.usecase.SaveUserIdUseCase
+import com.w36495.randomrithm.domain.usecase.SetCacheUserIdUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -14,11 +18,17 @@ import javax.inject.Inject
 class LoginViewModel @Inject constructor(
     private val checkUserIdUseCase: CheckUserIdUseCase,
     private val getCachedUserInfoUseCase: GetCachedUserInfoUseCase,
+    private val saveUserIdUseCase: SaveUserIdUseCase,
+    private val loadUserIdUseCase: LoadUserIdUseCase,
+    private var setCacheUserIdUseCase: SetCacheUserIdUseCase,
 ) : ViewModel() {
+    private var _cacheState = MutableLiveData<Boolean>()
     private var _loginState = MutableLiveData<Boolean>()
     private var _error = MutableLiveData<String>()
     val error: LiveData<String> get() = _error
     val loginState: LiveData<Boolean> get() = _loginState
+    val loadUserId: Flow<String?> = loadUserIdUseCase.invoke()
+    val cacheState: LiveData<Boolean> = _cacheState
 
     fun checkUserAccount(userId: String) {
         viewModelScope.launch {
@@ -40,6 +50,19 @@ class LoginViewModel @Inject constructor(
         }
 
         return userId
+    }
+
+    fun saveUserId(userId: String) {
+        viewModelScope.launch {
+            saveUserIdUseCase(userId)
+        }
+    }
+
+    fun setCacheUserId(userId: String) {
+        viewModelScope.launch {
+            val result = setCacheUserIdUseCase(userId)
+            _cacheState.value = result
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/w36495/randomrithm/presentation/onboarding/OnboardingFragment.kt
+++ b/app/src/main/java/com/w36495/randomrithm/presentation/onboarding/OnboardingFragment.kt
@@ -59,7 +59,7 @@ class OnboardingFragment : Fragment() {
 
         binding.btnLogin.setOnClickListener {
             if (hasUserId) loginViewModel.setCacheUserId(userId)
-            else navController.navigate(R.id.action_onboarding_to_login)
+            else navController.navigate(R.id.action_onboardingFragment_to_loginFragment)
         }
 
         binding.btnJustLooking.setOnClickListener {

--- a/app/src/main/java/com/w36495/randomrithm/presentation/onboarding/OnboardingFragment.kt
+++ b/app/src/main/java/com/w36495/randomrithm/presentation/onboarding/OnboardingFragment.kt
@@ -6,17 +6,28 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.findNavController
 import com.w36495.randomrithm.R
 import com.w36495.randomrithm.databinding.FragmentOnboardingBinding
 import com.w36495.randomrithm.presentation.MainActivity
+import com.w36495.randomrithm.presentation.home.HomeActivity
+import com.w36495.randomrithm.presentation.login.LoginViewModel
+import com.w36495.randomrithm.utils.showShortToast
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class OnboardingFragment : Fragment() {
     private var _binding: FragmentOnboardingBinding? = null
     private val binding: FragmentOnboardingBinding get() = _binding!!
+    private val loginViewModel by viewModels<LoginViewModel>()
     private val navController by lazy { binding.root.findNavController() }
+
+    private var hasUserId = false
+    private lateinit var userId: String
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -30,8 +41,25 @@ class OnboardingFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        viewLifecycleOwner.lifecycleScope.launch {
+            loginViewModel.loadUserId.collectLatest {
+                it?.let {
+                    userId = it
+                    hasUserId = true
+                }
+            }
+        }
+
+        loginViewModel.cacheState.observe(viewLifecycleOwner) {
+            if (it) {
+                requireContext().showShortToast("$userId 계정으로 로그인되었습니다.")
+                startActivity(Intent(requireActivity(), HomeActivity::class.java))
+            }
+        }
+
         binding.btnLogin.setOnClickListener {
-            navController.navigate(R.id.action_onboardingFragment_to_loginFragment)
+            if (hasUserId) loginViewModel.setCacheUserId(userId)
+            else navController.navigate(R.id.action_onboarding_to_login)
         }
 
         binding.btnJustLooking.setOnClickListener {

--- a/app/src/main/java/com/w36495/randomrithm/presentation/problem/ProblemFragment.kt
+++ b/app/src/main/java/com/w36495/randomrithm/presentation/problem/ProblemFragment.kt
@@ -77,11 +77,12 @@ class ProblemFragment : Fragment() {
         }
 
         problemViewModel.problemType.observe(viewLifecycleOwner) { problemType ->
-            val user = problemViewModel.getUserInfo()
+            val hasUserInfo = problemViewModel.hasCacheUserInfo
 
-            user?.let {
-                problemViewModel.getSolvableProblems(it.id, problemType)
-            } ?: problemViewModel.getProblems(problemType)
+            with (problemViewModel) {
+                if (hasUserInfo) getSolvableProblems(problemType)
+                else getProblems(problemType)
+            }
         }
 
         problemViewModel.loading.observe(viewLifecycleOwner) {

--- a/app/src/main/java/com/w36495/randomrithm/presentation/problem/ProblemFragment.kt
+++ b/app/src/main/java/com/w36495/randomrithm/presentation/problem/ProblemFragment.kt
@@ -96,10 +96,8 @@ class ProblemFragment : Fragment() {
         }
 
         problemViewModel.error.observe(viewLifecycleOwner) {
-            if (!it.equals("")) {
-                Toast.makeText(requireContext(), it, Toast.LENGTH_SHORT).show()
-                navController.popBackStack()
-            }
+            Toast.makeText(requireContext(), it, Toast.LENGTH_SHORT).show()
+            navController.popBackStack()
         }
 
         viewLifecycleOwner.lifecycleScope.launch {

--- a/app/src/main/java/com/w36495/randomrithm/presentation/problem/ProblemViewModel.kt
+++ b/app/src/main/java/com/w36495/randomrithm/presentation/problem/ProblemViewModel.kt
@@ -65,9 +65,9 @@ class ProblemViewModel @Inject constructor(
         }
     }
 
-    fun getSolvableProblems(userId: String, problemType: ProblemType) {
+    fun getSolvableProblems(problemType: ProblemType) {
         viewModelScope.launch {
-            val result = getSolvableProblemsUseCase(userId, problemType)
+            val result = getSolvableProblemsUseCase(problemType)
             _problems.value = result
         }
     }

--- a/app/src/main/java/com/w36495/randomrithm/presentation/problem/ProblemViewModel.kt
+++ b/app/src/main/java/com/w36495/randomrithm/presentation/problem/ProblemViewModel.kt
@@ -6,11 +6,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.w36495.randomrithm.domain.entity.Problem
 import com.w36495.randomrithm.domain.entity.ProblemType
-import com.w36495.randomrithm.domain.entity.User
-import com.w36495.randomrithm.domain.usecase.GetCachedUserInfoUseCase
 import com.w36495.randomrithm.domain.usecase.GetProblemsUseCase
 import com.w36495.randomrithm.domain.usecase.GetSolvableProblemsUseCase
 import com.w36495.randomrithm.domain.usecase.GetTagStateUseCase
+import com.w36495.randomrithm.domain.usecase.HasCacheUserInfoUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
@@ -21,7 +20,7 @@ class ProblemViewModel @Inject constructor(
     private val getTagStateUseCase: GetTagStateUseCase,
     private val getProblemsUseCase: GetProblemsUseCase,
     private val getSolvableProblemsUseCase: GetSolvableProblemsUseCase,
-    private val getCachedUserInfoUseCase: GetCachedUserInfoUseCase,
+    private val hasCacheUserInfoUseCase: HasCacheUserInfoUseCase,
 ) : ViewModel() {
     private var savedProblem: Problem? = null
     private var currentProblemIndex: Int = INIT_PROBLEM_INDEX
@@ -30,7 +29,7 @@ class ProblemViewModel @Inject constructor(
     private val _problems = MutableLiveData<List<Problem>>()
     private val _problem = MutableLiveData<Problem>()
     private val _loading = MutableLiveData(false)
-    private val _error = MutableLiveData("")
+    private val _error = MutableLiveData<String>()
 
     val problem: LiveData<Problem> get() = _problem
     val problems: LiveData<List<Problem>> get() = _problems
@@ -38,6 +37,7 @@ class ProblemViewModel @Inject constructor(
     val loading: LiveData<Boolean> get() = _loading
     val error: LiveData<String> get() = _error
     val tagState: Flow<Boolean> = getTagStateUseCase.invoke()
+    val hasCacheUserInfo = hasCacheUserInfoUseCase()
 
     fun initCurrentProblemType(problemType: ProblemType) {
         _problemType.value = problemType
@@ -52,18 +52,6 @@ class ProblemViewModel @Inject constructor(
     private fun getSavedProblem(): Problem {
         _loading.value = false
         return this.savedProblem!!
-    }
-
-    fun getUserInfo(): User? {
-        var user: User? = null
-
-        try {
-            user = getCachedUserInfoUseCase()
-        } catch (exception: Exception) {
-            _error.value = exception.message.toString()
-        }
-
-        return user
     }
 
     fun getProblem(problems: List<Problem>) {

--- a/app/src/main/res/layout/fragment_login.xml
+++ b/app/src/main/res/layout/fragment_login.xml
@@ -79,6 +79,16 @@
         app:layout_constraintStart_toStartOf="@id/et_id"
         app:layout_constraintTop_toBottomOf="@id/et_id" />
 
+    <CheckBox
+        android:id="@+id/cb_save_userId"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:checked="false"
+        android:text="@string/tv_login_saved_id"
+        app:layout_constraintBottom_toTopOf="@id/btn_login"
+        app:layout_constraintStart_toStartOf="parent" />
+
     <Button
         android:id="@+id/btn_login"
         android:layout_width="0dp"

--- a/app/src/main/res/layout/fragment_onboarding.xml
+++ b/app/src/main/res/layout/fragment_onboarding.xml
@@ -5,17 +5,96 @@
     android:layout_height="match_parent"
     android:background="@color/white">
 
-    <TextView
-        android:id="@+id/tv_title"
-        android:layout_width="0dp"
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout_title"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="150dp"
-        android:text="@string/tv_onboarding_title"
-        android:textSize="28sp"
-        android:textStyle="bold"
+        android:layout_marginStart="24dp"
+        app:layout_constraintBottom_toTopOf="@id/btn_login"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:id="@+id/tv_al"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="알"
+            android:textColor="@color/black"
+            android:textSize="48sp"
+            android:textStyle="bold"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_gorithm"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="4dp"
+            android:text="고리즘"
+            android:textColor="@color/black"
+            android:textSize="32sp"
+            app:layout_constraintBaseline_toBaselineOf="@id/tv_al"
+            app:layout_constraintBottom_toBottomOf="@id/tv_al"
+            app:layout_constraintStart_toEndOf="@id/tv_al" />
+
+        <TextView
+            android:id="@+id/tv_ran"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="랜"
+            android:textColor="@color/black"
+            android:textSize="48sp"
+            android:textStyle="bold"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_al" />
+
+        <TextView
+            android:id="@+id/tv_dom"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="4dp"
+            android:text="덤"
+            android:textColor="@color/black"
+            android:textSize="32sp"
+            app:layout_constraintBaseline_toBaselineOf="@id/tv_ran"
+            app:layout_constraintBottom_toBottomOf="@id/tv_ran"
+            app:layout_constraintStart_toEndOf="@id/tv_ran" />
+
+        <TextView
+            android:id="@+id/tv_de"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="디"
+            android:textColor="@color/black"
+            android:textSize="48sp"
+            android:textStyle="bold"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_ran" />
+
+        <TextView
+            android:id="@+id/pence"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="4dp"
+            android:text="펜스"
+            android:textColor="@color/black"
+            android:textSize="32sp"
+            app:layout_constraintBaseline_toBaselineOf="@id/tv_de"
+            app:layout_constraintBottom_toBottomOf="@id/tv_de"
+            app:layout_constraintStart_toEndOf="@id/tv_de" />
+
+        <TextView
+            android:id="@+id/tv_randomrithm"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="를 위한 랜덤리즘"
+            android:textColor="@color/black"
+            android:textSize="32sp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_de" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
     <Button
         android:id="@+id/btn_login"

--- a/app/src/main/res/menu/nav_onboarding.xml
+++ b/app/src/main/res/menu/nav_onboarding.xml
@@ -3,10 +3,10 @@
 
     <item
         android:id="@+id/nav_onboarding"
-        android:title="온보딩" />
+        android:title="@string/nav_onboarding" />
 
     <item
         android:id="@+id/nav_login"
-        android:title="로그인" />
+        android:title="@string/nav_login" />
 
 </menu>


### PR DESCRIPTION
## ISSUE
아이디 기억하기 (#64 )

## 고민
### 🤔 최초 로그인이 아닌 두번째 로그인일 때, 사용자 정보를 어느 타이밍에 Cache 에 저장해야 할까?
**1️⃣ 홈 화면으로 넘어왔을 때, DataStore 에 저장된 사용자 아이디를 확인한 후에 Cache 에 저장하기**
-> Home 화면에서 사용자의 정보를 상단에 보여주어야 하는데, 홈화면에서 Cache 에 저장을 하면 데이터가 업데이트되기 전에 사용자의 정보를 보여주는 setupUserProfile() 함수가 호출된다 ..
그리고 순서적으로 데이터가 갖춰진 상태에서 홈 화면으로 넘어와야 한다고 생각 함 ..

**2️⃣ 온보딩 화면에서 로그인 버튼을 클릭했을 때, Cache 에 저장하기**
홈 화면에 들어가기 전에, 사용자 정보가 저장되어 있어야 홈화면에서 정상적으로 기능이 동작한다!
``` kotlin
// OnboardingFragment.kt

override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
    super.onViewCreated(view, savedInstanceState)

    viewLifecycleOwner.lifecycleScope.launch {
        // 1. 온보딩 화면에서 로그인 버튼을 클릭했을 때, 저장된 사용자 계정이 있는지 확인
        loginViewModel.loadUserId.collectLatest {
            it?.let {
                userId = it
                hasUserId = true
            }
        }
    }

    loginViewModel.cacheState.observe(viewLifecycleOwner) {
        // 3. Cache 에 저장이 완료되었음을 LiveData 로 전달받고, 온보딩 화면에 관찰자를 등록하여 값 변화를 관찰한다.
        if (it) {
            // 4. 성공적으로 저장이 완료되면 홈 화면으로 이동시킨다.
            requireContext().showShortToast("$userId 계정으로 로그인되었습니다.")
            startActivity(Intent(requireActivity(), HomeActivity::class.java))
        }
    }

    binding.btnLogin.setOnClickListener {
        // 2. 사용자 계정이 존재한다면, SetCachUserIdUseCase() 를 통해 사용자 정보를 Cache 에 저장하기
        if (hasUserId) loginViewModel.setCacheUserId(userId)
        else navController.navigate(R.id.action_onboardingFragment_to_loginFragment)
    }
        // 5. 사용자 계정이 존재하지 않다면, 로그인 화면으로 이동시킨다!
    binding.btnJustLooking.setOnClickListener {
        startActivity(Intent(requireActivity(), MainActivity::class.java))
    }
}
```

## Result
<img src="https://github.com/w36495/randomrithm/assets/52291662/e6e46afe-4b80-47b1-8923-f2965910222d" width=50%>
