### PR TITLE
[feat/RANDOM-69] 로그아웃 기능 구현

### DIFF
--- a/app/src/main/java/com/w36495/randomrithm/di/UseCaseModule.kt
+++ b/app/src/main/java/com/w36495/randomrithm/di/UseCaseModule.kt
@@ -2,6 +2,7 @@ package com.w36495.randomrithm.di
 
 import android.content.Context
 import com.w36495.randomrithm.domain.usecase.ChangeTagStateUseCase
+import com.w36495.randomrithm.domain.usecase.ClearUserIdUseCase
 import com.w36495.randomrithm.domain.usecase.GetTagStateUseCase
 import com.w36495.randomrithm.domain.usecase.LoadUserIdUseCase
 import com.w36495.randomrithm.domain.usecase.SaveUserIdUseCase
@@ -33,4 +34,9 @@ object UseCaseModule {
     fun provideLoadUserIdUseCase(
         @ApplicationContext context: Context
     ): LoadUserIdUseCase = LoadUserIdUseCase(context)
+
+    @Provides
+    fun provideClearUserIdUseCase(
+        @ApplicationContext context: Context
+    ): ClearUserIdUseCase = ClearUserIdUseCase(context)
 }

--- a/app/src/main/java/com/w36495/randomrithm/domain/usecase/ClearUserIdUseCase.kt
+++ b/app/src/main/java/com/w36495/randomrithm/domain/usecase/ClearUserIdUseCase.kt
@@ -1,0 +1,17 @@
+package com.w36495.randomrithm.domain.usecase
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import com.w36495.randomrithm.domain.usecase.SaveUserIdUseCase.Companion.USER_ID_KEY
+import com.w36495.randomrithm.domain.usecase.SaveUserIdUseCase.Companion.dataStoreForUser
+import javax.inject.Inject
+
+class ClearUserIdUseCase @Inject constructor(
+    private val context: Context
+) {
+    suspend operator fun invoke() {
+        context.dataStoreForUser.edit {
+            it.remove(USER_ID_KEY)
+        }
+    }
+}

--- a/app/src/main/java/com/w36495/randomrithm/presentation/settings/LogoutDialog.kt
+++ b/app/src/main/java/com/w36495/randomrithm/presentation/settings/LogoutDialog.kt
@@ -1,0 +1,47 @@
+package com.w36495.randomrithm.presentation.settings
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.DialogFragment
+import com.w36495.randomrithm.databinding.DialogLogoutBinding
+import com.w36495.randomrithm.utils.dialogFragmentResize
+
+class LogoutDialog(
+    private val onClickLogout: () -> Unit
+) : DialogFragment() {
+    private var _binding: DialogLogoutBinding? = null
+    private val binding: DialogLogoutBinding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        _binding = DialogLogoutBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onResume() {
+        super.onResume()
+        context?.dialogFragmentResize(this@LogoutDialog, SIZE_WIDTH_PERCENT)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.tvCancel.setOnClickListener { dismiss() }
+        binding.tvOkay.setOnClickListener { onClickLogout() }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    companion object {
+        private const val SIZE_WIDTH_PERCENT = 0.9f
+        const val TAG: String = "LogoutDialog"
+    }
+}

--- a/app/src/main/java/com/w36495/randomrithm/presentation/settings/SettingFragment.kt
+++ b/app/src/main/java/com/w36495/randomrithm/presentation/settings/SettingFragment.kt
@@ -9,8 +9,12 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
+import androidx.navigation.findNavController
 import com.w36495.randomrithm.BuildConfig
 import com.w36495.randomrithm.databinding.FragmentSettingBinding
+import com.w36495.randomrithm.presentation.onboarding.OnboardingActivity
+import com.w36495.randomrithm.utils.Constants
+import com.w36495.randomrithm.utils.showShortToast
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -21,6 +25,7 @@ class SettingFragment : Fragment() {
     private val binding: FragmentSettingBinding get() = _binding!!
 
     private val viewModel: SettingViewModel by viewModels()
+    private val navController by lazy { binding.root.findNavController() }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -36,6 +41,11 @@ class SettingFragment : Fragment() {
 
         sendSurvey()
 
+        if (viewModel.hasUserInfo) {
+            binding.dvBetweenSurveyLogout.visibility = View.VISIBLE
+            binding.layoutLogout.visibility = View.VISIBLE
+        }
+
         binding.switchTag.setOnCheckedChangeListener { _, isChecked ->
             viewModel.changeTagState(isChecked)
         }
@@ -44,6 +54,14 @@ class SettingFragment : Fragment() {
             viewModel.tagState.collectLatest {
                 binding.switchTag.isChecked = it
             }
+        }
+
+        binding.layoutLogout.setOnClickListener {
+            LogoutDialog( onClickLogout = {
+                viewModel.resetUserIdUseCase()
+                requireContext().showShortToast(Constants.SUCCESS_LOGOUT.message)
+                startActivity(Intent(requireActivity(), OnboardingActivity::class.java))
+            }).show(childFragmentManager, LogoutDialog.TAG)
         }
     }
 

--- a/app/src/main/java/com/w36495/randomrithm/presentation/settings/SettingViewModel.kt
+++ b/app/src/main/java/com/w36495/randomrithm/presentation/settings/SettingViewModel.kt
@@ -3,7 +3,9 @@ package com.w36495.randomrithm.presentation.settings
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.w36495.randomrithm.domain.usecase.ChangeTagStateUseCase
+import com.w36495.randomrithm.domain.usecase.ClearUserIdUseCase
 import com.w36495.randomrithm.domain.usecase.GetTagStateUseCase
+import com.w36495.randomrithm.domain.usecase.HasCacheUserInfoUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
@@ -12,13 +14,22 @@ import javax.inject.Inject
 @HiltViewModel
 class SettingViewModel @Inject constructor(
     private val changeTagStateUseCase: ChangeTagStateUseCase,
-    private val getTagStateUseCase: GetTagStateUseCase
+    private val getTagStateUseCase: GetTagStateUseCase,
+    private val clearUserIdUseCase: ClearUserIdUseCase,
+    private val hasCacheUserInfoUseCase: HasCacheUserInfoUseCase,
 ) : ViewModel() {
     val tagState: Flow<Boolean> = getTagStateUseCase.invoke()
+    val hasUserInfo = hasCacheUserInfoUseCase()
 
     fun changeTagState(isChecked: Boolean) {
         viewModelScope.launch {
             changeTagStateUseCase.invoke(isChecked)
+        }
+    }
+
+    fun resetUserIdUseCase() {
+        viewModelScope.launch {
+            clearUserIdUseCase()
         }
     }
 }

--- a/app/src/main/java/com/w36495/randomrithm/utils/Constants.kt
+++ b/app/src/main/java/com/w36495/randomrithm/utils/Constants.kt
@@ -7,6 +7,8 @@ enum class Constants(val message: String) {
     LOGIN_SUGGESTION_CHECK_ACCOUNT("계정 확인을 해주세요."),
     LOGIN_SUGGESTION_INPUT_ACCOUNT("올바른 아이디를 입력해주세요."),
 
+    SUCCESS_LOGOUT("성공적으로 로그아웃 되었습니다."),
+
     EXCEPTION_WRONG_INPUT("잘못된 입력입니다. 다시 입력해주세요."),
     EXCEPTION_NOT_EXIST_PROBLEM("문제가 존재하지 않습니다."),
     EXCEPTION_DATA_ROAD_FAILED("데이터를 불러오는데 실패하였습니다."),

--- a/app/src/main/java/com/w36495/randomrithm/utils/extentions.kt
+++ b/app/src/main/java/com/w36495/randomrithm/utils/extentions.kt
@@ -2,9 +2,13 @@ package com.w36495.randomrithm.utils
 
 import android.content.Context
 import android.content.res.Resources
+import android.graphics.Point
+import android.os.Build
 import android.os.Bundle
 import android.util.TypedValue
+import android.view.WindowManager
 import android.widget.Toast
+import androidx.fragment.app.DialogFragment
 import com.w36495.randomrithm.data.entity.LevelDTO
 import com.w36495.randomrithm.data.entity.ProblemDTO
 import com.w36495.randomrithm.domain.entity.Problem
@@ -46,3 +50,25 @@ inline val Int.dp: Int
     get() = TypedValue.applyDimension(
         TypedValue.COMPLEX_UNIT_DIP, this.toFloat(), Resources.getSystem().displayMetrics
     ).toInt()
+
+fun Context.dialogFragmentResize(dialogFragment: DialogFragment, width: Float) {
+    val windowManager = getSystemService(Context.WINDOW_SERVICE) as WindowManager
+
+    if (Build.VERSION.SDK_INT < 30) {
+        val dialogParams = dialogFragment.dialog?.window?.attributes
+        val display = windowManager.defaultDisplay
+        val size = Point()
+
+        display.getSize(size)
+
+        dialogParams?.width = (size.x * width).toInt()
+        dialogFragment.dialog?.window?.attributes = dialogParams
+
+    } else {
+        val rect = windowManager.currentWindowMetrics.bounds
+        val dialogParams = dialogFragment.dialog?.window?.attributes
+
+        dialogParams?.width = (rect.width() * width).toInt()
+        dialogFragment.dialog?.window?.attributes = dialogParams
+    }
+}

--- a/app/src/main/res/drawable/ic_logout_24.xml
+++ b/app/src/main/res/drawable/ic_logout_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:autoMirrored="true" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M17,7l-1.41,1.41L18.17,11H8v2h10.17l-2.58,2.58L17,17l5,-5zM4,5h8V3H4c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h8v-2H4V5z"/>
+    
+</vector>

--- a/app/src/main/res/layout/dialog_logout.xml
+++ b/app/src/main/res/layout/dialog_logout.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/inline_layout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <TextView
+            android:id="@+id/tv_title"
+            android:layout_width="0dp"
+            android:layout_height="?attr/actionBarSize"
+            android:gravity="center"
+            android:text="@string/tv_logout_title"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <com.google.android.material.divider.MaterialDivider
+            android:id="@+id/divider"
+            android:layout_width="0dp"
+            android:layout_height="2dp"
+            app:dividerColor="@color/dv_grey"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_title" />
+
+        <TextView
+            android:id="@+id/tv_cancel"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:paddingVertical="16dp"
+            android:text="@string/dialog_btn_cancel"
+            android:textAlignment="center"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/tv_okay"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/divider" />
+
+        <TextView
+            android:id="@+id/tv_okay"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:paddingVertical="16dp"
+            android:text="@string/dialog_btn_okay"
+            android:textAlignment="center"
+            android:textColor="@color/design_default_color_primary"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/tv_cancel"
+            app:layout_constraintTop_toBottomOf="@id/divider" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_setting.xml
+++ b/app/src/main/res/layout/fragment_setting.xml
@@ -91,6 +91,41 @@
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
+        <com.google.android.material.divider.MaterialDivider
+            android:id="@+id/dv_between_survey_logout"
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:visibility="invisible" />
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/layout_logout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingVertical="8dp"
+            android:visibility="invisible">
+
+            <TextView
+                android:id="@+id/tv_logout"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:text="@string/tv_logout"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@id/iBtn_logout"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <ImageButton
+                android:id="@+id/iBtn_logout"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@android:color/transparent"
+                android:src="@drawable/ic_logout_24"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
     </LinearLayout>
 
     <TextView

--- a/app/src/main/res/navigation/nav_graph_home.xml
+++ b/app/src/main/res/navigation/nav_graph_home.xml
@@ -31,7 +31,11 @@
         android:id="@+id/nav_settings"
         android:name="com.w36495.randomrithm.presentation.settings.SettingFragment"
         android:label="SettingFragment"
-        tools:layout="@layout/fragment_setting" />
+        tools:layout="@layout/fragment_setting" >
+        <action
+            android:id="@+id/action_nav_settings_to_logoutDialog"
+            app:destination="@id/nav_logout" />
+    </fragment>
 
     <fragment
         android:id="@+id/nav_home"
@@ -46,5 +50,11 @@
             android:id="@+id/action_nav_home_to_nav_tag"
             app:destination="@id/nav_tag" />
     </fragment>
+
+    <dialog
+        android:id="@+id/nav_logout"
+        android:name="com.w36495.randomrithm.presentation.settings.LogoutDialog"
+        tools:layout="@layout/dialog_logout"
+        android:label="LogoutDialog" />
 
 </navigation>

--- a/app/src/main/res/values-night/strings.xml
+++ b/app/src/main/res/values-night/strings.xml
@@ -55,6 +55,8 @@
     <string name="nav_source">출처</string>
     <string name="nav_onboarding">온보딩</string>
     <string name="nav_login">로그인</string>
+    <string name="tv_logout_title">로그아웃 하시겠습니까?</string>
+    <string name="tv_logout">로그아웃</string>
 
     <string-array name="levelForTabItem">
         <item>Unrank</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,6 +55,8 @@
     <string name="nav_source">출처</string>
     <string name="nav_onboarding">온보딩</string>
     <string name="nav_login">로그인</string>
+    <string name="tv_logout_title">로그아웃 하시겠습니까?</string>
+    <string name="tv_logout">로그아웃</string>
 
     <string-array name="levelForTabItem">
         <item>Unrank</item>


### PR DESCRIPTION
## ISSUE
로그아웃 기능 구현 (#69 )

## 고려한 부분
### 로그인을 하지 않은 상태 -> 로그아웃 버튼을 보이지 않도록 하였다!
<img width="351" alt="스크린샷 2024-04-19 00 54 25" src="https://github.com/w36495/randomrithm/assets/52291662/6eb0bdab-524b-40ac-8258-0d8f24a4f602">


## Result
<img src="https://github.com/w36495/randomrithm/assets/52291662/afefdbc0-8a61-4b33-a357-afcd54ce6bd9" width=50%>

- 로그아웃 버튼을 클릭하면 DataStore 에 저장되어 있는 사용자의 정보가 지워지며, 처음 페이지인 온보딩 페이지로 화면을 전환해주었다!