### PR TITLE
[refactor/RANDOM-72] 사용자가 푼 문제목록 캐싱하기

### DIFF
--- a/app/src/main/java/com/w36495/randomrithm/data/entity/AlgorithmDTO.kt
+++ b/app/src/main/java/com/w36495/randomrithm/data/entity/AlgorithmDTO.kt
@@ -26,7 +26,14 @@ data class AlgorithmItem(
     val key: String,
     @Json(name = "problemCount")
     val problemCount: Int
-)
+) {
+    fun toDomainModel() = Tag(
+        id = this.bojTagId,
+        key = this.key,
+        name = this.displayNames[0].name,
+        problemCount = this.problemCount
+    )
+}
 
 @JsonClass(generateAdapter = true)
 data class DisplayName(
@@ -36,11 +43,4 @@ data class DisplayName(
     val name: String,
     @Json(name = "short")
     val short: String
-)
-
-fun AlgorithmItem.toDomainModel() = Tag(
-    id = this.bojTagId,
-    key = this.key,
-    name = this.displayNames[0].name,
-    problemCount = this.problemCount
 )

--- a/app/src/main/java/com/w36495/randomrithm/data/entity/ProblemDTO.kt
+++ b/app/src/main/java/com/w36495/randomrithm/data/entity/ProblemDTO.kt
@@ -71,7 +71,14 @@ data class Tag(
     val key: String,
     @Json(name = "problemCount")
     val problemCount: Int
-)
+) {
+    fun toDomainModel() = com.w36495.randomrithm.domain.entity.Tag(
+        id = bojTagId,
+        key = this.key,
+        name = this.displayNames[0].name,
+        problemCount = this.problemCount
+    )
+}
 
 @JsonClass(generateAdapter = true)
 class Metadata
@@ -87,11 +94,4 @@ fun ProblemItem.toDomainModel() = Problem(
     level = this.level.toString(),
     title = this.titleKo,
     tags = this.tags.map { it.toDomainModel() }
-)
-
-fun Tag.toDomainModel() = com.w36495.randomrithm.domain.entity.Tag(
-    id = bojTagId,
-    key = this.key,
-    name = this.displayNames[0].name,
-    problemCount = this.problemCount
 )

--- a/app/src/main/java/com/w36495/randomrithm/data/entity/UserDTO.kt
+++ b/app/src/main/java/com/w36495/randomrithm/data/entity/UserDTO.kt
@@ -72,10 +72,10 @@ data class UserInfoDTO(
     val tier: Int,
     @Json(name = "voteCount")
     val voteCount: Int
-)
-
-fun UserInfoDTO.toDomainModel() = User(
-    id = handle,
-    tier = tier,
-    solvedCount = solvedCount
-)
+) {
+    fun toDomainModel() = User(
+        id = handle,
+        tier = tier,
+        solvedCount = solvedCount
+    )
+}

--- a/app/src/main/java/com/w36495/randomrithm/data/repository/ProblemRepositoryImpl.kt
+++ b/app/src/main/java/com/w36495/randomrithm/data/repository/ProblemRepositoryImpl.kt
@@ -2,14 +2,29 @@ package com.w36495.randomrithm.data.repository
 
 import com.w36495.randomrithm.data.datasource.ProblemRemoteDataSource
 import com.w36495.randomrithm.data.entity.ProblemDTO
+import com.w36495.randomrithm.data.entity.ProblemItem
 import com.w36495.randomrithm.data.entity.SproutProblemDTO
 import com.w36495.randomrithm.domain.repository.ProblemRepository
+import com.w36495.randomrithm.utils.Constants
 import retrofit2.Response
 import javax.inject.Inject
 
 class ProblemRepositoryImpl @Inject constructor(
     private val problemRemoteDataSource: ProblemRemoteDataSource,
 ) : ProblemRepository {
+    private var solvedProblems: List<ProblemItem>? = null
+
+    override fun getCacheSolvedProblems(): List<ProblemItem> {
+        when (hasCacheSolvedProblems()) {
+            true -> return this.solvedProblems!!
+            false -> throw IllegalStateException(Constants.EXCEPTION_DATA_ROAD_FAILED.message)
+        }
+    }
+
+    override fun setCacheSolvedProblems(problems: List<ProblemItem>) {
+        this.solvedProblems = problems
+    }
+
     override suspend fun fetchProblems(query: String): Response<ProblemDTO> {
         return problemRemoteDataSource.fetchProblems(query)
     }
@@ -18,5 +33,9 @@ class ProblemRepositoryImpl @Inject constructor(
     }
     override suspend fun fetchSolvedProblems(query: String, page: Int): Response<ProblemDTO> {
         return problemRemoteDataSource.fetchSolvedProblems(query, page)
+    }
+
+    private fun hasCacheSolvedProblems(): Boolean {
+        return solvedProblems?.let { true } ?: false
     }
 }

--- a/app/src/main/java/com/w36495/randomrithm/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/w36495/randomrithm/data/repository/UserRepositoryImpl.kt
@@ -10,8 +10,12 @@ class UserRepositoryImpl @Inject constructor(
 ) : UserRepository {
     private var user: UserInfoDTO? = null
 
-    override fun getCachedUserInfo(): UserInfoDTO? {
-        return this.user
+    override fun getCacheUserInfo(): UserInfoDTO {
+        return this.user!!
+    }
+
+    override fun hasCacheUserInfo(): Boolean {
+        return this.user?.let { true } ?: false
     }
 
     override suspend fun getUser(query: String): Boolean {
@@ -20,7 +24,7 @@ class UserRepositoryImpl @Inject constructor(
         if (result.isSuccessful) {
             result.body()?.let { dto ->
                 if (dto.count == 1) {
-                    user = dto.items[0]
+                    saveCacheUserInfo(dto.items[0])
                     return true
                 }
             }
@@ -33,11 +37,15 @@ class UserRepositoryImpl @Inject constructor(
 
         if (result.isSuccessful) {
             result.body()?.let {
-                user = it
+                saveCacheUserInfo(it)
                 return true
             }
         }
 
         return false
+    }
+
+    private fun saveCacheUserInfo(user: UserInfoDTO) {
+        this.user = user
     }
 }

--- a/app/src/main/java/com/w36495/randomrithm/di/RepositoryModule.kt
+++ b/app/src/main/java/com/w36495/randomrithm/di/RepositoryModule.kt
@@ -28,6 +28,7 @@ abstract class RepositoryModule {
     ): LevelRepository
 
     @Binds
+    @Singleton
     abstract fun bindProblemRepository(
         problemRepositoryImpl: ProblemRepositoryImpl
     ): ProblemRepository

--- a/app/src/main/java/com/w36495/randomrithm/domain/repository/ProblemRepository.kt
+++ b/app/src/main/java/com/w36495/randomrithm/domain/repository/ProblemRepository.kt
@@ -1,10 +1,13 @@
 package com.w36495.randomrithm.domain.repository
 
 import com.w36495.randomrithm.data.entity.ProblemDTO
+import com.w36495.randomrithm.data.entity.ProblemItem
 import com.w36495.randomrithm.data.entity.SproutProblemDTO
 import retrofit2.Response
 
 interface ProblemRepository {
+    fun getCacheSolvedProblems(): List<ProblemItem>
+    fun setCacheSolvedProblems(problems: List<ProblemItem>)
     suspend fun fetchProblems(query: String): Response<ProblemDTO>
     suspend fun fetchProblemsOfSprout(): Response<List<SproutProblemDTO>>
     suspend fun fetchSolvedProblems(userId: String, page: Int): Response<ProblemDTO>

--- a/app/src/main/java/com/w36495/randomrithm/domain/repository/UserRepository.kt
+++ b/app/src/main/java/com/w36495/randomrithm/domain/repository/UserRepository.kt
@@ -3,7 +3,8 @@ package com.w36495.randomrithm.domain.repository
 import com.w36495.randomrithm.data.entity.UserInfoDTO
 
 interface UserRepository {
-    fun getCachedUserInfo(): UserInfoDTO?
+    fun getCacheUserInfo(): UserInfoDTO
+    fun hasCacheUserInfo(): Boolean
     suspend fun getUser(query: String): Boolean
     suspend fun getUserInfo(userId: String): Boolean
 }

--- a/app/src/main/java/com/w36495/randomrithm/domain/usecase/GetCacheSolvedProblemsUseCase.kt
+++ b/app/src/main/java/com/w36495/randomrithm/domain/usecase/GetCacheSolvedProblemsUseCase.kt
@@ -1,0 +1,16 @@
+package com.w36495.randomrithm.domain.usecase
+
+import com.w36495.randomrithm.data.entity.toDomainModel
+import com.w36495.randomrithm.domain.entity.Problem
+import com.w36495.randomrithm.domain.repository.ProblemRepository
+import javax.inject.Inject
+
+class GetCacheSolvedProblemsUseCase @Inject constructor(
+    private val problemRepository: ProblemRepository,
+) {
+    operator fun invoke(): List<Problem> {
+        return problemRepository.getCacheSolvedProblems().map {
+            it.toDomainModel()
+        }
+    }
+}

--- a/app/src/main/java/com/w36495/randomrithm/domain/usecase/GetCacheUserInfoUseCase.kt
+++ b/app/src/main/java/com/w36495/randomrithm/domain/usecase/GetCacheUserInfoUseCase.kt
@@ -6,16 +6,13 @@ import com.w36495.randomrithm.domain.repository.UserRepository
 import com.w36495.randomrithm.utils.Constants
 import javax.inject.Inject
 
-class GetCachedUserInfoUseCase @Inject constructor(
+class GetCacheUserInfoUseCase @Inject constructor(
     private val userRepository: UserRepository,
 ) {
     operator fun invoke(): User {
-        val result = userRepository.getCachedUserInfo()
-
-        val user = result?.let {
-            it.toDomainModel()
-        } ?: throw IllegalStateException(Constants.EXCEPTION_NOT_EXIST_USER.message)
-
-        return user
+        when (userRepository.hasCacheUserInfo()) {
+            true -> return userRepository.getCacheUserInfo().toDomainModel()
+            false -> throw IllegalStateException(Constants.EXCEPTION_NOT_EXIST_USER.message)
+        }
     }
 }

--- a/app/src/main/java/com/w36495/randomrithm/domain/usecase/GetSolvableProblemsUseCase.kt
+++ b/app/src/main/java/com/w36495/randomrithm/domain/usecase/GetSolvableProblemsUseCase.kt
@@ -6,12 +6,12 @@ import javax.inject.Inject
 
 class GetSolvableProblemsUseCase @Inject constructor(
     private val getProblemsUseCase: GetProblemsUseCase,
-    private val getSolvedProblemsUseCase: GetSolvedProblemsUseCase,
+    private val getCacheSolvedProblemsUseCase: GetCacheSolvedProblemsUseCase,
 ) {
     suspend operator fun invoke(problemType: ProblemType): List<Problem> {
         val solvableProblems = mutableListOf<Problem>()
         val problems = getProblemsUseCase(problemType)
-        val solvedProblems = getSolvedProblemsUseCase()
+        val solvedProblems = getCacheSolvedProblemsUseCase()
 
         problems.forEach { problem ->
             if (isSolvableProblem(problem, solvedProblems)) solvableProblems.addAll(problems)

--- a/app/src/main/java/com/w36495/randomrithm/domain/usecase/GetSolvedProblemsUseCase.kt
+++ b/app/src/main/java/com/w36495/randomrithm/domain/usecase/GetSolvedProblemsUseCase.kt
@@ -1,7 +1,7 @@
 package com.w36495.randomrithm.domain.usecase
 
+import com.w36495.randomrithm.data.entity.ProblemItem
 import com.w36495.randomrithm.data.entity.toDomainModel
-import com.w36495.randomrithm.domain.entity.Problem
 import com.w36495.randomrithm.domain.repository.ProblemRepository
 import com.w36495.randomrithm.domain.repository.UserRepository
 import com.w36495.randomrithm.utils.Constants
@@ -11,17 +11,17 @@ class GetSolvedProblemsUseCase @Inject constructor(
     private val userRepository: UserRepository,
     private val problemRepository: ProblemRepository
 ) {
-    suspend operator fun invoke(): List<Problem> {
+    suspend operator fun invoke(): List<ProblemItem> {
         return getUserInfo()
     }
 
-    private suspend fun getUserInfo(): List<Problem> {
+    private suspend fun getUserInfo(): List<ProblemItem> {
         val user = userRepository.getCacheUserInfo().toDomainModel()
         return getSolvedProblems(user.id, user.solvedCount)
     }
 
-    private suspend fun getSolvedProblems(userId: String, solvedProblemCount: Int): List<Problem> {
-        val solvedProblems = mutableListOf<Problem>()
+    private suspend fun getSolvedProblems(userId: String, solvedProblemCount: Int): List<ProblemItem> {
+        val solvedProblems = mutableListOf<ProblemItem>()
         val lastPage = calculatePageOfProblems(solvedProblemCount)
         val query = "%40$userId"
 
@@ -30,7 +30,7 @@ class GetSolvedProblemsUseCase @Inject constructor(
 
             if (result.isSuccessful) {
                 result.body()?.let { problemDto ->
-                    solvedProblems.addAll(problemDto.items.map { it.toDomainModel() })
+                    solvedProblems.addAll(problemDto.items)
                 }
             } else {
                 throw IllegalStateException(Constants.EXCEPTION_DATA_ROAD_FAILED.message)

--- a/app/src/main/java/com/w36495/randomrithm/domain/usecase/GetSolvedProblemsUseCase.kt
+++ b/app/src/main/java/com/w36495/randomrithm/domain/usecase/GetSolvedProblemsUseCase.kt
@@ -16,7 +16,7 @@ class GetSolvedProblemsUseCase @Inject constructor(
     }
 
     private suspend fun getUserInfo(): List<Problem> {
-        val user = userRepository.getCachedUserInfo()!!.toDomainModel()
+        val user = userRepository.getCacheUserInfo().toDomainModel()
         return getSolvedProblems(user.id, user.solvedCount)
     }
 

--- a/app/src/main/java/com/w36495/randomrithm/domain/usecase/HasCacheUserInfoUseCase.kt
+++ b/app/src/main/java/com/w36495/randomrithm/domain/usecase/HasCacheUserInfoUseCase.kt
@@ -7,6 +7,6 @@ class HasCacheUserInfoUseCase @Inject constructor(
     private val userRepository: UserRepository,
 ) {
     operator fun invoke(): Boolean {
-        return userRepository.getCachedUserInfo()?.let { true } ?: false
+        return userRepository.hasCacheUserInfo()
     }
 }

--- a/app/src/main/java/com/w36495/randomrithm/domain/usecase/SaveCacheSolvedProblemsUseCase.kt
+++ b/app/src/main/java/com/w36495/randomrithm/domain/usecase/SaveCacheSolvedProblemsUseCase.kt
@@ -1,0 +1,13 @@
+package com.w36495.randomrithm.domain.usecase
+
+import com.w36495.randomrithm.domain.repository.ProblemRepository
+import javax.inject.Inject
+
+class SaveCacheSolvedProblemsUseCase @Inject constructor(
+    private val problemRepository: ProblemRepository,
+    private val getSolvedProblemsUseCase: GetSolvedProblemsUseCase,
+) {
+    suspend operator fun invoke() {
+        problemRepository.setCacheSolvedProblems(getSolvedProblemsUseCase())
+    }
+}

--- a/app/src/main/java/com/w36495/randomrithm/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/w36495/randomrithm/presentation/home/HomeViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.w36495.randomrithm.domain.entity.Tag
-import com.w36495.randomrithm.domain.usecase.GetCachedUserInfoUseCase
+import com.w36495.randomrithm.domain.usecase.GetCacheUserInfoUseCase
 import com.w36495.randomrithm.domain.usecase.GetTagsUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
@@ -14,13 +14,13 @@ import javax.inject.Inject
 @HiltViewModel
 class HomeViewModel @Inject constructor(
     private val getTagsUseCase: GetTagsUseCase,
-    private val getCachedUserInfoUseCase: GetCachedUserInfoUseCase,
+    private val getCacheUserInfoUseCase: GetCacheUserInfoUseCase,
 ) : ViewModel() {
     private var _error = MutableLiveData<String>()
     private var _tags = MutableLiveData<List<Tag>>()
     val tags: LiveData<List<Tag>> get() = _tags
     val error: LiveData<String> get() = _error
-    val user = getCachedUserInfoUseCase()
+    val user = getCacheUserInfoUseCase()
 
     init {
         loadInitData()

--- a/app/src/main/java/com/w36495/randomrithm/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/w36495/randomrithm/presentation/home/HomeViewModel.kt
@@ -7,7 +7,9 @@ import androidx.lifecycle.viewModelScope
 import com.w36495.randomrithm.domain.entity.Tag
 import com.w36495.randomrithm.domain.usecase.GetCacheUserInfoUseCase
 import com.w36495.randomrithm.domain.usecase.GetTagsUseCase
+import com.w36495.randomrithm.domain.usecase.SaveCacheSolvedProblemsUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -15,6 +17,8 @@ import javax.inject.Inject
 class HomeViewModel @Inject constructor(
     private val getTagsUseCase: GetTagsUseCase,
     private val getCacheUserInfoUseCase: GetCacheUserInfoUseCase,
+    private val saveCacheSolvedProblemsUseCase: SaveCacheSolvedProblemsUseCase,
+
 ) : ViewModel() {
     private var _error = MutableLiveData<String>()
     private var _tags = MutableLiveData<List<Tag>>()
@@ -28,6 +32,7 @@ class HomeViewModel @Inject constructor(
 
     private fun loadInitData() {
         viewModelScope.launch {
+            async { saveCacheSolvedProblemsUseCase() }.await()
             _tags.value = getTagsUseCase.invoke().subList(0, 10)
         }
     }

--- a/app/src/main/java/com/w36495/randomrithm/presentation/login/LoginViewModel.kt
+++ b/app/src/main/java/com/w36495/randomrithm/presentation/login/LoginViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.w36495.randomrithm.domain.usecase.CheckUserIdUseCase
-import com.w36495.randomrithm.domain.usecase.GetCachedUserInfoUseCase
+import com.w36495.randomrithm.domain.usecase.GetCacheUserInfoUseCase
 import com.w36495.randomrithm.domain.usecase.LoadUserIdUseCase
 import com.w36495.randomrithm.domain.usecase.SaveUserIdUseCase
 import com.w36495.randomrithm.domain.usecase.SetCacheUserIdUseCase
@@ -17,7 +17,7 @@ import javax.inject.Inject
 @HiltViewModel
 class LoginViewModel @Inject constructor(
     private val checkUserIdUseCase: CheckUserIdUseCase,
-    private val getCachedUserInfoUseCase: GetCachedUserInfoUseCase,
+    private val getCacheUserInfoUseCase: GetCacheUserInfoUseCase,
     private val saveUserIdUseCase: SaveUserIdUseCase,
     private val loadUserIdUseCase: LoadUserIdUseCase,
     private var setCacheUserIdUseCase: SetCacheUserIdUseCase,
@@ -44,7 +44,7 @@ class LoginViewModel @Inject constructor(
         var userId: String? = null
 
         try {
-            userId = getCachedUserInfoUseCase().id
+            userId = getCacheUserInfoUseCase().id
         } catch (exception: Exception) {
             _error.value = exception.message.toString()
         }


### PR DESCRIPTION
## ISSUE
사용자가 푼 문제목록 캐싱하기 (#72 )

## 수정된 내용
**가장 큰 차이점은 서버에 데이터 요청하는 일이 줄어들었다는 점!**
문제를 서버로부터 받아올 때마다 사용자가 푼 문제목록도 함께 받아온 후 -> 풀지 않은 문제목록으로 가공하였는데
이전에 풀었던 문제 목록을 미리 받아와서 재사용하니 지속적으로 사용자가 풀었던 문제를 서버에 요청하지 않아도 되게 되었다.

또한, Home 화면에서 사용자 정보를 UI에 보여줘야하기때문에 저장된 사용자 정보를 불러왔어야 했다.
그래서 사용자 정보를 불러오는 김에 사용자가 풀었던 문제 목록도 초기에 가져오면 좋을 것 같다는 생각을 해서 수정하게 되었다.
사용자 정보를 불러올 때, 이전에 저장되어있지 않다면(불러오기가 실패되었다면) 예외를 발생시켜주었다.
``` kotlin
class GetCacheUserInfoUseCase @Inject constructor(
    private val userRepository: UserRepository,
) {
    operator fun invoke(): User {
        when (userRepository.hasCacheUserInfo()) {
            true -> return userRepository.getCacheUserInfo().toDomainModel()
            false -> throw IllegalStateException(Constants.EXCEPTION_NOT_EXIST_USER.message)
        }
    }
}
```
--> 예외를 처리하는 부분은 아직 작성하지 못했는데, 새로고침 혹은 로그인페이지로 화면을 이동시키면 될 것 같다.


