### PR TITLE
[feat/RANDOM-76]  Home 화면에서 알고리즘 선택 시, 세부적인 레벨 선택 기능

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -4,6 +4,17 @@
     <value>
       <entry key="app">
         <State>
+          <runningDeviceTargetSelectedWithDropDown>
+            <Target>
+              <type value="RUNNING_DEVICE_TARGET" />
+              <deviceKey>
+                <Key>
+                  <type value="VIRTUAL_DEVICE_PATH" />
+                  <value value="$USER_HOME$/.android/avd/Pixel_XL_API_32.avd" />
+                </Key>
+              </deviceKey>
+            </Target>
+          </runningDeviceTargetSelectedWithDropDown>
           <targetSelectedWithDropDown>
             <Target>
               <type value="QUICK_BOOT_TARGET" />
@@ -15,7 +26,7 @@
               </deviceKey>
             </Target>
           </targetSelectedWithDropDown>
-          <timeTargetWasSelectedWithDropDown value="2024-04-19T08:51:53.332080Z" />
+          <timeTargetWasSelectedWithDropDown value="2024-04-23T07:47:00.565311Z" />
         </State>
       </entry>
     </value>

--- a/app/src/main/java/com/w36495/randomrithm/domain/usecase/HasProblemOfTagUseCase.kt
+++ b/app/src/main/java/com/w36495/randomrithm/domain/usecase/HasProblemOfTagUseCase.kt
@@ -6,16 +6,22 @@ import javax.inject.Inject
 class HasProblemOfTagUseCase @Inject constructor(
     private val problemRepository: ProblemRepository
 ) {
-    suspend operator fun invoke(tag: String, level: Char): Boolean {
-        val query = "solvable:true+%23$tag+*$level"
+    suspend operator fun invoke(tag: String): List<Boolean> {
+        val levels = listOf('b', 's', 'g', 'p', 'd', 'r')
+        val results = mutableListOf<Boolean>()
 
-        val result = problemRepository.fetchProblems(query)
-        if (result.isSuccessful) {
-            result.body()?.let {
-                if (it.count == 0) return false
+        levels.forEach { level ->
+            val query = "solvable:true+%23$tag+*$level"
+
+            val result = problemRepository.fetchProblems(query)
+            if (result.isSuccessful) {
+                result.body()?.let {
+                    if (it.count == 0) results.add(false)
+                    else results.add(true)
+                }
             }
         }
 
-        return true
+        return results.toList()
     }
 }

--- a/app/src/main/java/com/w36495/randomrithm/presentation/home/HomeFragment.kt
+++ b/app/src/main/java/com/w36495/randomrithm/presentation/home/HomeFragment.kt
@@ -18,15 +18,17 @@ import com.w36495.randomrithm.domain.entity.SolvedCountType
 import com.w36495.randomrithm.domain.entity.SourceType
 import com.w36495.randomrithm.domain.entity.SproutType
 import com.w36495.randomrithm.domain.entity.Tag
-import com.w36495.randomrithm.domain.entity.TagType
+import com.w36495.randomrithm.domain.entity.TagAndLevelType
 import com.w36495.randomrithm.domain.entity.User
+import com.w36495.randomrithm.presentation.tag.LevelSelectionClickListener
+import com.w36495.randomrithm.presentation.tag.LevelSelectionDialog
 import com.w36495.randomrithm.presentation.tag.TagFragment
 import com.w36495.randomrithm.utils.putProblemType
 import com.w36495.randomrithm.utils.showShortToast
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class HomeFragment : Fragment(), PopularAlgorithmClickListener {
+class HomeFragment : Fragment(), PopularAlgorithmClickListener, LevelSelectionClickListener {
     private var _binding: FragmentHomeBinding? = null
     private val binding: FragmentHomeBinding get() = _binding!!
     private val homeViewModel by viewModels<HomeViewModel>()
@@ -73,6 +75,13 @@ class HomeFragment : Fragment(), PopularAlgorithmClickListener {
 
             tags.observe(viewLifecycleOwner) { tags ->
                 popularAlgorithmAdapter.setupPopularTags(tags)
+            }
+
+            hasLevels.observe(viewLifecycleOwner) {
+                val tag = it.getValue("tag").toString()
+                val levels = it.getValue("levels") as List<Boolean>
+
+                openLevelSelectionDialog(tag, levels)
             }
         }
     }
@@ -122,8 +131,22 @@ class HomeFragment : Fragment(), PopularAlgorithmClickListener {
         )
     }
 
+    private fun openLevelSelectionDialog(tag: String, levels: List<Boolean>) {
+        LevelSelectionDialog().apply {
+            setLevelSelectionClickListener(this@HomeFragment)
+            arguments = Bundle().apply {
+                putString("tag", tag)
+                putBooleanArray("levels", levels.toBooleanArray())
+            }
+        }.show(parentFragmentManager, "LevelSelectionDialog")
+    }
+
     override fun onClickPopularAlgorithm(tag: Tag) {
-        moveProblemFragment(TagType(tag = tag.key))
+        homeViewModel.hasProblemOfTag(tag.key)
+    }
+
+    override fun onClickLevel(level: Int, tag: String) {
+        moveProblemFragment(TagAndLevelType(tag = tag, level = level))
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/w36495/randomrithm/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/w36495/randomrithm/presentation/home/HomeViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewModelScope
 import com.w36495.randomrithm.domain.entity.Tag
 import com.w36495.randomrithm.domain.usecase.GetCacheUserInfoUseCase
 import com.w36495.randomrithm.domain.usecase.GetTagsUseCase
+import com.w36495.randomrithm.domain.usecase.HasProblemOfTagUseCase
 import com.w36495.randomrithm.domain.usecase.SaveCacheSolvedProblemsUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.async
@@ -16,13 +17,16 @@ import javax.inject.Inject
 @HiltViewModel
 class HomeViewModel @Inject constructor(
     private val getTagsUseCase: GetTagsUseCase,
+    private val hasProblemOfTagUseCase: HasProblemOfTagUseCase,
     private val getCacheUserInfoUseCase: GetCacheUserInfoUseCase,
     private val saveCacheSolvedProblemsUseCase: SaveCacheSolvedProblemsUseCase,
 
 ) : ViewModel() {
     private var _error = MutableLiveData<String>()
     private var _tags = MutableLiveData<List<Tag>>()
+    private var _hasLevels = MutableLiveData<Map<String, Any>>()
     val tags: LiveData<List<Tag>> get() = _tags
+    val hasLevels: LiveData<Map<String, Any>> get() = _hasLevels
     val error: LiveData<String> get() = _error
     val user = getCacheUserInfoUseCase()
 
@@ -34,6 +38,16 @@ class HomeViewModel @Inject constructor(
         viewModelScope.launch {
             async { saveCacheSolvedProblemsUseCase() }.await()
             _tags.value = getTagsUseCase.invoke().subList(0, 10)
+        }
+    }
+
+    fun hasProblemOfTag(tag: String) {
+        val tempMap = mutableMapOf<String, Any>()
+        tempMap["tag"] = tag
+
+        viewModelScope.launch {
+            tempMap["levels"] = hasProblemOfTagUseCase.invoke(tag)
+            _hasLevels.value = tempMap.toMap()
         }
     }
 }

--- a/app/src/main/java/com/w36495/randomrithm/presentation/tag/TagViewModel.kt
+++ b/app/src/main/java/com/w36495/randomrithm/presentation/tag/TagViewModel.kt
@@ -9,8 +9,6 @@ import com.w36495.randomrithm.domain.entity.Tag
 import com.w36495.randomrithm.domain.usecase.GetTagsUseCase
 import com.w36495.randomrithm.domain.usecase.HasProblemOfTagUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -47,19 +45,7 @@ class TagViewModel @Inject constructor(
 
     fun hasProblemOfTag(tag: String) {
         viewModelScope.launch {
-            try {
-                val bronze = async { hasProblemOfTagUseCase.invoke(tag, 'b') }
-                val silver = async { hasProblemOfTagUseCase.invoke(tag, 's') }
-                val gold = async { hasProblemOfTagUseCase.invoke(tag, 'g') }
-                val platinum = async { hasProblemOfTagUseCase.invoke(tag, 'p') }
-                val diamond = async { hasProblemOfTagUseCase.invoke(tag, 'd') }
-                val ruby = async { hasProblemOfTagUseCase.invoke(tag, 'd') }
-
-                val result = awaitAll(bronze, silver, gold, platinum, diamond, ruby)
-                _problemCountOfTag.value = result
-            } catch (exception: Exception) {
-
-            }
+            _problemCountOfTag.value = hasProblemOfTagUseCase.invoke(tag)
         }
     }
 


### PR DESCRIPTION
## ISSUE
Home 화면에서 알고리즘 선택 시, 세부적인 레벨 선택 기능 (#76 )

## Refactor
기존에 알고리즘목록을 보여주었던 화면(TagFragment)에서는 ViewModel 에서 브론즈부터 루비까지의 레벨을 하나하나 HasProblemOfTagUseCase() 를 호출하였고, awaitAll() 을 통해 결과값을 사용하였었다.
``` kotlin
fun hasProblemOfTag(tag: String) {
    viewModelScope.launch {
        try {
            val bronze = async { hasProblemOfTagUseCase.invoke(tag, 'b') }
            val silver = async { hasProblemOfTagUseCase.invoke(tag, 's') }
            val gold = async { hasProblemOfTagUseCase.invoke(tag, 'g') }
            val platinum = async { hasProblemOfTagUseCase.invoke(tag, 'p') }
            val diamond = async { hasProblemOfTagUseCase.invoke(tag, 'd') }
            val ruby = async { hasProblemOfTagUseCase.invoke(tag, 'd') }

            val result = awaitAll(bronze, silver, gold, platinum, diamond, ruby)
            _problemCountOfTag.value = result
        } catch (exception: Exception) {

        }
        _problemCountOfTag.value = hasProblemOfTagUseCase.invoke(tag)
    }
}
```

위에 있는 함수를 Home 화면에서도 똑같이 사용해야했는데, 같은 함수를 작성하자니 좋은 방법이 아닌 것 같았다 .. 

그래서 ViewModel 에서 진행했던 브론즈부터 루비까지의 동작을 HasProblemOfTagUseCase() 에서 수행하는 것으로 수정하였다.
``` kotlin
// 수정 전 
class HasProblemOfTagUseCase @Inject constructor(
    private val problemRepository: ProblemRepository
) {
    suspend operator fun invoke(tag: String, level: Char): Boolean {
        val query = "solvable:true+%23$tag+*$level"

        val result = problemRepository.fetchProblems(query)
        if (result.isSuccessful) {
            result.body()?.let {
                if (it.count == 0) return false
            }
        }

        return true
    }
}

// 수정 후
class HasProblemOfTagUseCase @Inject constructor(
    private val problemRepository: ProblemRepository
) {
    suspend operator fun invoke(tag: String): List<Boolean> {
        val levels = listOf('b', 's', 'g', 'p', 'd', 'r')
        val results = mutableListOf<Boolean>()

        levels.forEach { level ->
            val query = "solvable:true+%23$tag+*$level"

            val result = problemRepository.fetchProblems(query)
            if (result.isSuccessful) {
                result.body()?.let {
                    if (it.count == 0) results.add(false)
                    else results.add(true)
                }
            }
        }

        return results.toList()
    }
}
```
브론즈~루비까지의 레벨들을 List 에 저장한 후에 for문을 통해 레벨에 해당되는 문제가 존재하는지 여부를 확인하였다.
결과값은 results 리스트에 담아 반환하도록 수정하였다.

같은 2개의 함수로 분리되지 않고 HasProblemOfTagUseCase() 에 작성함으로써 TagViewModel 뿐만 아니라 HomeViewModel 에서도 동일한 동작을 할 수 있게 되었다!

## Result
|`Before`|`After`|
|:--:|:--:|
|![기능 수정 전](https://github.com/w36495/randomrithm/assets/52291662/63e9ffb0-e774-442f-b378-c9a232ce36a3)|![기능 수정 후](https://github.com/w36495/randomrithm/assets/52291662/4684cb83-f652-45c2-a625-332e49b85a06)|
|알고리즘 버튼 클릭 시, 레벨이 랜덤으로 보여짐|알고리즘 버튼 클릭 시, 세부 레벨 선택 화면이 보여짐|