### PR TITLE
[refactor/RANDOM-78] Activity 간의 이동 관련해서 Navigation 수정

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,8 +26,20 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity android:name=".presentation.MainActivity" />
-        <activity android:name=".presentation.home.HomeActivity" />
+        <activity
+            android:name=".presentation.MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+            </intent-filter>
+        </activity>
+        <activity
+            android:name=".presentation.home.HomeActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+            </intent-filter>
+        </activity>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/w36495/randomrithm/domain/usecase/GetSolvableProblemsUseCase.kt
+++ b/app/src/main/java/com/w36495/randomrithm/domain/usecase/GetSolvableProblemsUseCase.kt
@@ -14,7 +14,7 @@ class GetSolvableProblemsUseCase @Inject constructor(
         val solvedProblems = getCacheSolvedProblemsUseCase()
 
         problems.forEach { problem ->
-            if (isSolvableProblem(problem, solvedProblems)) solvableProblems.addAll(problems)
+            if (isSolvableProblem(problem, solvedProblems)) solvableProblems.add(problem)
         }
 
         return solvableProblems.toList()
@@ -27,11 +27,11 @@ class GetSolvableProblemsUseCase @Inject constructor(
         while (start < end) {
             val middle = (start + end) / 2
 
-            if (solvedProblem[middle].id == problem.id) return true
-            else if (solvedProblem[middle].id < problem.id) end = middle - 1
-            else start = middle + 1
+            if (solvedProblem[middle].id == problem.id) return false
+            else if (solvedProblem[middle].id < problem.id) start = middle + 1
+            else end = middle - 1
         }
 
-        return false
+        return true
     }
 }

--- a/app/src/main/java/com/w36495/randomrithm/presentation/login/LoginFragment.kt
+++ b/app/src/main/java/com/w36495/randomrithm/presentation/login/LoginFragment.kt
@@ -1,6 +1,5 @@
 package com.w36495.randomrithm.presentation.login
 
-import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -8,8 +7,8 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.findNavController
+import com.w36495.randomrithm.R
 import com.w36495.randomrithm.databinding.FragmentLoginBinding
-import com.w36495.randomrithm.presentation.home.HomeActivity
 import com.w36495.randomrithm.utils.Constants
 import com.w36495.randomrithm.utils.showShortToast
 import dagger.hilt.android.AndroidEntryPoint
@@ -89,7 +88,8 @@ class LoginFragment : Fragment() {
     }
 
     private fun moveHomeActivity() {
-        startActivity(Intent(requireActivity(), HomeActivity::class.java))
+        navController.navigate(R.id.nav_home)
+        requireActivity().finish()
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/w36495/randomrithm/presentation/onboarding/OnboardingFragment.kt
+++ b/app/src/main/java/com/w36495/randomrithm/presentation/onboarding/OnboardingFragment.kt
@@ -53,7 +53,7 @@ class OnboardingFragment : Fragment() {
         loginViewModel.cacheState.observe(viewLifecycleOwner) {
             if (it) {
                 requireContext().showShortToast("$userId 계정으로 로그인되었습니다.")
-                startActivity(Intent(requireActivity(), HomeActivity::class.java))
+                navController.navigate(R.id.nav_home)
             }
         }
 
@@ -63,7 +63,7 @@ class OnboardingFragment : Fragment() {
         }
 
         binding.btnJustLooking.setOnClickListener {
-            startActivity(Intent(requireActivity(), MainActivity::class.java))
+            navController.navigate(R.id.nav_main)
         }
     }
 

--- a/app/src/main/java/com/w36495/randomrithm/presentation/onboarding/OnboardingFragment.kt
+++ b/app/src/main/java/com/w36495/randomrithm/presentation/onboarding/OnboardingFragment.kt
@@ -1,6 +1,5 @@
 package com.w36495.randomrithm.presentation.onboarding
 
-import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -11,8 +10,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.navigation.findNavController
 import com.w36495.randomrithm.R
 import com.w36495.randomrithm.databinding.FragmentOnboardingBinding
-import com.w36495.randomrithm.presentation.MainActivity
-import com.w36495.randomrithm.presentation.home.HomeActivity
 import com.w36495.randomrithm.presentation.login.LoginViewModel
 import com.w36495.randomrithm.utils.showShortToast
 import dagger.hilt.android.AndroidEntryPoint
@@ -54,6 +51,7 @@ class OnboardingFragment : Fragment() {
             if (it) {
                 requireContext().showShortToast("$userId 계정으로 로그인되었습니다.")
                 navController.navigate(R.id.nav_home)
+                requireActivity().finish()
             }
         }
 
@@ -64,6 +62,7 @@ class OnboardingFragment : Fragment() {
 
         binding.btnJustLooking.setOnClickListener {
             navController.navigate(R.id.nav_main)
+            requireActivity().finish()
         }
     }
 

--- a/app/src/main/java/com/w36495/randomrithm/presentation/settings/SettingFragment.kt
+++ b/app/src/main/java/com/w36495/randomrithm/presentation/settings/SettingFragment.kt
@@ -11,8 +11,8 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.findNavController
 import com.w36495.randomrithm.BuildConfig
+import com.w36495.randomrithm.R
 import com.w36495.randomrithm.databinding.FragmentSettingBinding
-import com.w36495.randomrithm.presentation.onboarding.OnboardingActivity
 import com.w36495.randomrithm.utils.Constants
 import com.w36495.randomrithm.utils.showShortToast
 import dagger.hilt.android.AndroidEntryPoint
@@ -60,7 +60,8 @@ class SettingFragment : Fragment() {
             LogoutDialog( onClickLogout = {
                 viewModel.resetUserIdUseCase()
                 requireContext().showShortToast(Constants.SUCCESS_LOGOUT.message)
-                startActivity(Intent(requireActivity(), OnboardingActivity::class.java))
+                navController.navigate(R.id.nav_onboarding)
+                requireActivity().finish()
             }).show(childFragmentManager, LogoutDialog.TAG)
         }
     }

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -2,7 +2,7 @@
 <navigation xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/navigation"
+    android:id="@+id/nav_graph"
     app:startDestination="@id/nav_level">
 
     <fragment
@@ -36,6 +36,12 @@
         <action
             android:id="@+id/action_tagFragment_to_problemFragment"
             app:destination="@id/nav_problem" />
+        <action
+            android:id="@+id/action_tagFragment_to_levelSelectionDialog"
+            app:destination="@id/nav_level_selection_dialog" />
+
+        <argument android:name="tag" app:argType="string" android:defaultValue="non-tag"/>
+        <argument android:name="level" app:argType="integer" android:defaultValue="-1"/>
     </fragment>
 
     <fragment
@@ -64,5 +70,14 @@
         android:name="com.w36495.randomrithm.presentation.settings.SettingFragment"
         android:label="SettingFragment"
         tools:layout="@layout/fragment_setting" />
+
+    <dialog
+        android:id="@+id/nav_level_selection_dialog"
+        android:name="com.w36495.randomrithm.presentation.tag.LevelSelectionDialog">
+        <action
+            android:id="@+id/action_levelSelectionDialog_to_tagFragment"
+            app:destination="@id/nav_tag" >
+        </action>
+    </dialog>
 
 </navigation>

--- a/app/src/main/res/navigation/nav_graph_home.xml
+++ b/app/src/main/res/navigation/nav_graph_home.xml
@@ -5,6 +5,12 @@
     android:id="@+id/nav_graph_home"
     app:startDestination="@+id/nav_home">
 
+    <activity
+        android:id="@+id/nav_onboarding"
+        android:name="com.w36495.randomrithm.presentation.onboarding.OnboardingActivity"
+        app:action="android.intent.action.VIEW"
+        tools:layout="@layout/activity_onboarding" />
+
     <fragment
         android:id="@+id/nav_tag"
         android:name="com.w36495.randomrithm.presentation.tag.TagFragment"
@@ -14,6 +20,8 @@
         <action
             android:id="@+id/action_tagFragment_to_problemFragment"
             app:destination="@id/nav_problem" />
+        <argument android:name="tag" app:argType="string" android:defaultValue="non-tag"/>
+        <argument android:name="level" app:argType="integer" android:defaultValue="-1"/>
     </fragment>
 
     <fragment
@@ -79,4 +87,11 @@
             app:destination="@id/nav_problem" />
     </fragment>
 
+    <dialog
+        android:id="@+id/nav_level_selection_dialog"
+        android:name="com.w36495.randomrithm.presentation.tag.LevelSelectionDialog">
+        <action
+            android:id="@+id/action_levelSelectionDialog_to_tagFragment"
+            app:destination="@id/nav_tag" />
+    </dialog>
 </navigation>

--- a/app/src/main/res/navigation/nav_graph_onboarding.xml
+++ b/app/src/main/res/navigation/nav_graph_onboarding.xml
@@ -5,6 +5,18 @@
     android:id="@+id/nav_graph_onboarding"
     app:startDestination="@id/nav_onboarding">
 
+    <activity
+        android:id="@+id/nav_main"
+        android:name="com.w36495.randomrithm.presentation.MainActivity"
+        app:action="android.intent.action.VIEW"
+        tools:layout="@layout/activity_main" />
+
+    <activity
+        android:id="@+id/nav_home"
+        android:name="com.w36495.randomrithm.presentation.home.HomeActivity"
+        app:action="android.intent.action.VIEW"
+        tools:layout="@layout/activity_home" />
+
     <fragment
         android:id="@+id/nav_onboarding"
         android:name="com.w36495.randomrithm.presentation.onboarding.OnboardingFragment"


### PR DESCRIPTION
## ISSUE
Activity 간의 이동 관련해서 Navigation 수정 (#78 )

## Result
새로운 activity 가 생성되면, activity 의 finish() 를 통해 이전 activity 를 종료시켜주었다.
### 수정 전 (이전 Activity가 그대로 남아있음)
|`비회원 로그인 후, 뒤로가기`|`로그인 후, 뒤로가기`|`로그아웃 후, 뒤로가기`|
|--|--|--|
|![비회원-로그인-후-뒤로가기](https://github.com/w36495/randomrithm/assets/52291662/d02bae86-d377-42c3-8dc4-9dc2ef2ac314)|![로그인-후-뒤로가기](https://github.com/w36495/randomrithm/assets/52291662/35c8582f-e6df-4f4b-90db-178a3f3b40fd)|![로그아웃-후-뒤로가기](https://github.com/w36495/randomrithm/assets/52291662/6f590ee0-b232-4294-9ef7-b30f4b48d816)|

### 수정 후 (이전 Activity가 남아있지 않으므로, 앱이 종료됨)
|`비회원 로그인 후, 뒤로가기`|`로그인 후, 뒤로가기`|`로그아웃 후, 뒤로가기`|
|--|--|--|
|![비회원-로그인-후-뒤로가기](https://github.com/w36495/randomrithm/assets/52291662/e16ebb1a-ef38-441c-bf36-9aa807054de4)|![로그인-후-뒤로가기](https://github.com/w36495/randomrithm/assets/52291662/4cbd20b9-e03b-4f2a-b6f2-a1f1dfa1881e)|![로그아웃-후-뒤로가기](https://github.com/w36495/randomrithm/assets/52291662/43bfd2f3-42be-4177-81dc-51d85ea3bbc4)|

