### PR TITLE
[bug/RANDOM-81> 앱 이름으로 onBoardingScreen 으로 보임

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,8 +18,7 @@
         tools:targetApi="31">
         <activity
             android:name=".presentation.onboarding.OnboardingActivity"
-            android:exported="true"
-            android:label="@string/title_activity_on_boarding_screen">
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/res/values-night/strings.xml
+++ b/app/src/main/res/values-night/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">Randomrithm</string>
+    <string name="app_name">랜덤리즘</string>
     <string name="dialog_title_change_problem">%1$s 관련 랜덤 문제로 이동하시겠습니까?</string>
     <string name="dialog_btn_okay">확인</string>
     <string name="dialog_btn_cancel">취소</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">Randomrithm</string>
+    <string name="app_name">랜덤리즘</string>
     <string name="dialog_title_change_problem">%1$s 관련 랜덤 문제로 이동하시겠습니까?</string>
     <string name="dialog_btn_okay">확인</string>
     <string name="dialog_btn_cancel">취소</string>


### PR DESCRIPTION
## ISSUE
앱 이름으로 onBoardingScreen 으로 보임 (#81 )

## 해결 과정
1. Manifest.xml 파일 내에 OnboardingActivity 를 선언하는 부분에서 다른 activity 와는 다르게 android:label 이 작성되어 있음을 확인
2. <activity> 내에 `android:label` 이 무엇을 뜻하는지 확인하였다.
> It's often displayed along with the activity icon. If this attribute isn't set, the label set for the application as a whole is used instead. see the [<application>](https://developer.android.com/guide/topics/manifest/application-element) element's [label](https://developer.android.com/guide/topics/manifest/application-element#label) attribute.
3. `android:label` 삭제

## 결과
<img width="345" alt="스크린샷 2024-04-24 18 21 59" src="https://github.com/w36495/randomrithm/assets/52291662/97934a60-112f-4560-b7aa-4bd15f36131a">
